### PR TITLE
fix: cleared cors issue to accept request from multiple hosts

### DIFF
--- a/services/.gitignore
+++ b/services/.gitignore
@@ -42,3 +42,4 @@ secrets.yml
 .git-hooks/
 application-local.yaml
 .idea
+DotEnv.env

--- a/services/beeja-cloud-gateway/src/main/java/com/beeja/api/apigateway/config/security/SecurityConfig.java
+++ b/services/beeja-cloud-gateway/src/main/java/com/beeja/api/apigateway/config/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import static org.springframework.security.web.server.util.matcher.ServerWebExch
 
 import com.beeja.api.apigateway.config.security.properties.AuthProperties;
 import java.time.Duration;
+import java.util.List;
 import java.util.ServiceLoader;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +19,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.authentication.ServerAuthenticationFailureHandler;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 import org.springframework.web.server.session.CookieWebSessionIdResolver;
 import reactor.core.publisher.Mono;
 
@@ -146,6 +150,22 @@ public class SecurityConfig {
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
   }
+
+
+  @Bean
+  public CorsWebFilter corsWebFilter() {
+    CorsConfiguration corsConfig = new CorsConfiguration();
+    corsConfig.setAllowedOriginPatterns(List.of(authProperties.getFrontEndUrl(), authProperties.getLocalFrontEndUrl()));
+    corsConfig.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+    corsConfig.setAllowedHeaders(List.of("*"));
+    corsConfig.setAllowCredentials(true);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", corsConfig);
+
+    return new CorsWebFilter(source);
+  }
+
 
   @Bean
   public CookieWebSessionIdResolver cookieSessionIdResolverWithoutSameSite() {

--- a/services/beeja-cloud-gateway/src/main/resources/application.yaml
+++ b/services/beeja-cloud-gateway/src/main/resources/application.yaml
@@ -94,7 +94,7 @@ eureka:
 
 auth.cors.allowed-origins:
   frontEndUrl: ${FRONT_END_URL}
-  localFrontEndUrl: ${LOCAL_FRONT_END_URL}
+  localFrontEndUrl: http://localhost:3000
 
 management:
   metrics:


### PR DESCRIPTION
This PR resolves the **CORS issue** that was preventing requests from multiple hosts (e.g., localhost and domain.com). The following updates have been made:
- Configured global CORS settings in the API Gateway to allow requests from localhost.
- Enabled allowedOriginPatterns instead of allowedOrigins for more flexible domain handling.
- Allowed all standard HTTP methods (GET, POST, PUT, DELETE, OPTIONS).

This fix ensures seamless API access from multiple frontend hosts during development.