### PR TITLE
Replace Hardcoded Strings with Localized Strings for Proper Translation Support

### DIFF
--- a/web/src/components/reusableComponents/CenterModal.component.tsx
+++ b/web/src/components/reusableComponents/CenterModal.component.tsx
@@ -18,7 +18,7 @@ type CenterModalProps = {
   handleModalSubmit: () => void;
   handleModalLeftButtonClick?: () => void;
   modalHeading?: string;
-  modalContent?: React.ReactNode;
+  modalContent?: string | React.ReactNode;
   modalSVG?: React.ReactNode;
   modalLeftButtonText?: string;
   modalRightButtonText?: string;
@@ -97,7 +97,9 @@ const CenterModal = (props: CenterModalProps) => {
                 <div className="modalHeading">
                   {t(props.modalHeading ? props.modalHeading : '')}
                 </div>
-                <div className="modalContent">{props.modalContent}</div>
+                <div className="modalContent">
+                  {typeof props.modalContent === 'string' ? t(props.modalContent) : props.modalContent}
+                </div>
               </>
             )}
           </div>


### PR DESCRIPTION
This PR replaces hardcoded strings in the modal component with localized strings using i18n for proper translation support.

- Applied `t()` translation function only to string props (e.g., `modalContent`,).
- Ensured non-string values (ReactNode elements) are rendered as-is without translation errors.
- Improved code readability and maintainability by handling translations before rendering JSX.