### PR TITLE
Implemented Pagination Support for List of Applicants API

### DIFF
--- a/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/controllers/ApplicantController.java
+++ b/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/controllers/ApplicantController.java
@@ -49,12 +49,13 @@ public class ApplicantController {
           @RequestParam(required = false) String positionAppliedFor,
           @RequestParam(required = false) ApplicantStatus status,
           @RequestParam(required = false) String experience,
-          @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) Date createdDate,
+          @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) Date fromDate,
+          @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) Date toDate,
           @RequestParam(required = false, defaultValue = "createdAt") String sortBy,
           @RequestParam(required = false, defaultValue = "desc") String sortDirection) {
 
     PaginatedApplicantResponse response = applicantService.getPaginatedApplicants(
-            page, limit, applicantId, firstName, positionAppliedFor, status, experience, createdDate, sortBy, sortDirection);
+            page, limit, applicantId, firstName, positionAppliedFor, status, experience, fromDate, toDate, sortBy, sortDirection);
     return ResponseEntity.ok(response);
   }
 

--- a/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/controllers/ApplicantController.java
+++ b/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/controllers/ApplicantController.java
@@ -3,21 +3,25 @@ package tac.beeja.recruitmentapi.controllers;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import tac.beeja.recruitmentapi.annotations.HasPermission;
+import tac.beeja.recruitmentapi.enums.ApplicantStatus;
 import tac.beeja.recruitmentapi.model.Applicant;
 import tac.beeja.recruitmentapi.model.AssignedInterviewer;
 import tac.beeja.recruitmentapi.request.AddCommentRequest;
 import tac.beeja.recruitmentapi.request.ApplicantFeedbackRequest;
 import tac.beeja.recruitmentapi.request.ApplicantRequest;
+import tac.beeja.recruitmentapi.response.PaginatedApplicantResponse;
 import tac.beeja.recruitmentapi.service.ApplicantService;
 import tac.beeja.recruitmentapi.utils.Constants;
 import tac.beeja.recruitmentapi.utils.ValidationUtil;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -33,6 +37,25 @@ public class ApplicantController {
   public ResponseEntity<Applicant> postApplicant(ApplicantRequest applicantRequest)
       throws Exception {
     return ResponseEntity.ok(applicantService.postApplicant(applicantRequest, false));
+  }
+
+  @GetMapping("/combinedApplicants")
+  @HasPermission(Constants.GET_APPLICANTS)
+  public ResponseEntity<PaginatedApplicantResponse> getApplicants(
+          @RequestParam(required = false) Integer page,
+          @RequestParam(required = false) Integer limit,
+          @RequestParam(required = false) String applicantId,
+          @RequestParam(required = false) String firstName,
+          @RequestParam(required = false) String positionAppliedFor,
+          @RequestParam(required = false) ApplicantStatus status,
+          @RequestParam(required = false) String experience,
+          @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) Date createdDate,
+          @RequestParam(required = false, defaultValue = "createdAt") String sortBy,
+          @RequestParam(required = false, defaultValue = "desc") String sortDirection) {
+
+    PaginatedApplicantResponse response = applicantService.getPaginatedApplicants(
+            page, limit, applicantId, firstName, positionAppliedFor, status, experience, createdDate, sortBy, sortDirection);
+    return ResponseEntity.ok(response);
   }
 
   @GetMapping

--- a/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/response/ApplicantDTO.java
+++ b/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/response/ApplicantDTO.java
@@ -1,0 +1,25 @@
+package tac.beeja.recruitmentapi.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import tac.beeja.recruitmentapi.enums.ApplicantStatus;
+
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApplicantDTO {
+    private String id;
+    private String applicantId;
+    private String firstName;
+    private String lastName;
+    private String email;
+    private String phoneNumber;
+    private String positionAppliedFor;
+    private ApplicantStatus status;
+    private String experience;
+    private String referredBy;
+    private Date createdAt;
+}

--- a/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/response/PaginatedApplicantResponse.java
+++ b/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/response/PaginatedApplicantResponse.java
@@ -1,0 +1,19 @@
+package tac.beeja.recruitmentapi.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaginatedApplicantResponse {
+    private List<ApplicantDTO> applicants;
+    private int currentPage;
+    private int pageSize;
+    private long totalRecords;
+    private int totalPages;
+}
+

--- a/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/service/ApplicantService.java
+++ b/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/service/ApplicantService.java
@@ -1,12 +1,15 @@
 package tac.beeja.recruitmentapi.service;
 
 import org.springframework.core.io.ByteArrayResource;
+import tac.beeja.recruitmentapi.enums.ApplicantStatus;
 import tac.beeja.recruitmentapi.model.Applicant;
 import tac.beeja.recruitmentapi.model.AssignedInterviewer;
 import tac.beeja.recruitmentapi.request.AddCommentRequest;
 import tac.beeja.recruitmentapi.request.ApplicantFeedbackRequest;
 import tac.beeja.recruitmentapi.request.ApplicantRequest;
+import tac.beeja.recruitmentapi.response.PaginatedApplicantResponse;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -31,4 +34,7 @@ public interface ApplicantService {
   Applicant addCommentToApplicant(AddCommentRequest addCommentRequest) throws Exception;
 
   Applicant changeStatusOfApplicant(String applicantId, String status) throws Exception;
+
+  PaginatedApplicantResponse getPaginatedApplicants(Integer page, Integer limit, String applicantId, String firstName, String positionAppliedFor, ApplicantStatus status, String experience, Date createdDate, String sortBy, String sortDirection);
+
 }

--- a/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/service/ApplicantService.java
+++ b/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/service/ApplicantService.java
@@ -35,6 +35,6 @@ public interface ApplicantService {
 
   Applicant changeStatusOfApplicant(String applicantId, String status) throws Exception;
 
-  PaginatedApplicantResponse getPaginatedApplicants(Integer page, Integer limit, String applicantId, String firstName, String positionAppliedFor, ApplicantStatus status, String experience, Date createdDate, String sortBy, String sortDirection);
+  PaginatedApplicantResponse getPaginatedApplicants(Integer page, Integer limit, String applicantId, String firstName, String positionAppliedFor, ApplicantStatus status, String experience, Date fromDate,Date toDate, String sortBy, String sortDirection);
 
 }

--- a/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/serviceImpl/ApplicantServiceImpl.java
+++ b/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/serviceImpl/ApplicantServiceImpl.java
@@ -1,10 +1,12 @@
 package tac.beeja.recruitmentapi.serviceImpl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.validation.constraints.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -30,8 +32,10 @@ import tac.beeja.recruitmentapi.request.AddCommentRequest;
 import tac.beeja.recruitmentapi.request.ApplicantFeedbackRequest;
 import tac.beeja.recruitmentapi.request.ApplicantRequest;
 import tac.beeja.recruitmentapi.request.FileRequest;
+import tac.beeja.recruitmentapi.response.ApplicantDTO;
 import tac.beeja.recruitmentapi.response.FileDownloadResultMetaData;
 import tac.beeja.recruitmentapi.response.FileResponse;
+import tac.beeja.recruitmentapi.response.PaginatedApplicantResponse;
 import tac.beeja.recruitmentapi.service.ApplicantService;
 import tac.beeja.recruitmentapi.utils.Constants;
 import tac.beeja.recruitmentapi.utils.UserContext;
@@ -39,15 +43,9 @@ import tac.beeja.recruitmentapi.utils.UserContext;
 import java.lang.reflect.Field;
 import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.regex.Matcher;
+import java.util.stream.Collectors;
 
-import static tac.beeja.recruitmentapi.utils.Constants.ERROR_IN_CREATING_APPLICANT;
-import static tac.beeja.recruitmentapi.utils.Constants.ERROR_IN_GETTING_LIST_OF_APPLICANTS;
-import static tac.beeja.recruitmentapi.utils.Constants.ERROR_IN_RESUME_UPLOAD;
-import static tac.beeja.recruitmentapi.utils.Constants.ERROR_IN_UPDATING_APPLICANTS;
-import static tac.beeja.recruitmentapi.utils.Constants.NO_APPLICANT_FOUND_WITH_GIVEN_ID;
-import static tac.beeja.recruitmentapi.utils.Constants.RESUME_FILE_ENTITY;
+import static tac.beeja.recruitmentapi.utils.Constants.*;
 
 @Service
 @Slf4j
@@ -104,6 +102,59 @@ public class ApplicantServiceImpl implements ApplicantService {
     }
   }
 
+  @Override
+  public PaginatedApplicantResponse getPaginatedApplicants(
+          Integer page, Integer limit, String applicantId, String firstName,
+          String positionAppliedFor, ApplicantStatus status, String experience,
+          Date createdDate, String sortBy, String sortDirection) {
+
+    int pageNumber = (page != null && page >= 1) ? page - 1 : 0;
+    int pageSize = (limit != null && limit > 0 && limit <= 100) ? limit : 10;
+
+    Pageable pageable = (sortBy != null && "asc".equalsIgnoreCase(sortDirection))
+            ? PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.ASC, sortBy))
+            : PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, sortBy != null ? sortBy : "createdAt"));
+
+    Query query = new Query().with(pageable);
+
+    if (applicantId != null && !applicantId.isEmpty()) {
+      query.addCriteria(Criteria.where("applicantId").is(applicantId));
+    }
+    if (firstName != null && !firstName.isEmpty()) {
+      query.addCriteria(Criteria.where("firstName").regex("^" + firstName + "$", "i"));
+    }
+    if (positionAppliedFor != null && !positionAppliedFor.isEmpty()) {
+      query.addCriteria(Criteria.where("positionAppliedFor").regex("^" + positionAppliedFor + "$", "i"));
+    }
+    if (status != null) {
+      query.addCriteria(Criteria.where("status").is(status));
+    }
+    if (experience != null && !experience.isEmpty()) {
+      query.addCriteria(Criteria.where("experience").regex("^" + experience + "$", "i"));
+    }
+    if (createdDate != null) {
+      query.addCriteria(Criteria.where("createdAt").gte(createdDate));
+    }
+
+    List<Applicant> applicants = mongoTemplate.find(query, Applicant.class);
+    long totalRecords = mongoTemplate.count(query, Applicant.class);
+
+    if (applicants.isEmpty()) {
+      return new PaginatedApplicantResponse(Collections.emptyList(), pageNumber + 1, pageSize, 0, 0);
+    }
+
+    List<ApplicantDTO> applicantDTOs = applicants.stream().map(applicant -> new ApplicantDTO(
+            applicant.getId(),applicant.getApplicantId(), applicant.getFirstName(), applicant.getLastName(),
+            applicant.getEmail(), applicant.getPhoneNumber(), applicant.getPositionAppliedFor(),
+            applicant.getStatus(), applicant.getExperience(), applicant.getReferredByEmployeeName(),
+            applicant.getCreatedAt()
+    )).collect(Collectors.toList());
+
+    int totalPages = (int) Math.ceil((double) totalRecords / pageSize);
+
+    return new PaginatedApplicantResponse(applicantDTOs, pageNumber + 1, pageSize, totalRecords, totalPages);
+
+  }
 
   private String generateApplicantId() {
 

--- a/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/serviceImpl/ApplicantServiceImpl.java
+++ b/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/serviceImpl/ApplicantServiceImpl.java
@@ -106,7 +106,7 @@ public class ApplicantServiceImpl implements ApplicantService {
   public PaginatedApplicantResponse getPaginatedApplicants(
           Integer page, Integer limit, String applicantId, String firstName,
           String positionAppliedFor, ApplicantStatus status, String experience,
-          Date createdDate, String sortBy, String sortDirection) {
+          Date fromDate,Date toDate, String sortBy, String sortDirection) {
 
     int pageNumber = (page != null && page >= 1) ? page - 1 : 0;
     int pageSize = (limit != null && limit > 0 && limit <= 100) ? limit : 10;
@@ -132,8 +132,26 @@ public class ApplicantServiceImpl implements ApplicantService {
     if (experience != null && !experience.isEmpty()) {
       query.addCriteria(Criteria.where("experience").regex("^" + experience + "$", "i"));
     }
-    if (createdDate != null) {
-      query.addCriteria(Criteria.where("createdAt").gte(createdDate));
+    if (fromDate != null && toDate != null) {
+      Calendar cal = Calendar.getInstance();
+      cal.setTime(toDate);
+      cal.set(Calendar.HOUR_OF_DAY, 23);
+      cal.set(Calendar.MINUTE, 59);
+      cal.set(Calendar.SECOND, 59);
+      cal.set(Calendar.MILLISECOND, 999);
+      toDate = cal.getTime();
+      query.addCriteria(Criteria.where("createdAt").gte(fromDate).lte(toDate));
+    } else if (fromDate != null) {
+      query.addCriteria(Criteria.where("createdAt").gte(fromDate));
+    } else if (toDate != null) {
+      Calendar cal = Calendar.getInstance();
+      cal.setTime(toDate);
+      cal.set(Calendar.HOUR_OF_DAY, 23);
+      cal.set(Calendar.MINUTE, 59);
+      cal.set(Calendar.SECOND, 59);
+      cal.set(Calendar.MILLISECOND, 999);
+      toDate = cal.getTime();
+      query.addCriteria(Criteria.where("createdAt").lte(toDate));
     }
 
     List<Applicant> applicants = mongoTemplate.find(query, Applicant.class);

--- a/services/beeja-recruitment/src/test/java/tac/beeja/recruitmentapi/serviceImpl/ApplicantServiceImplTest.java
+++ b/services/beeja-recruitment/src/test/java/tac/beeja/recruitmentapi/serviceImpl/ApplicantServiceImplTest.java
@@ -1,0 +1,200 @@
+package tac.beeja.recruitmentapi.serviceImpl;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import tac.beeja.recruitmentapi.enums.ApplicantStatus;
+import tac.beeja.recruitmentapi.model.Applicant;
+import tac.beeja.recruitmentapi.response.PaginatedApplicantResponse;
+
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+class ApplicantServiceImplTest {
+
+    @InjectMocks
+    private ApplicantServiceImpl applicantServiceImpl;
+
+    @Mock
+    private MongoTemplate mongoTemplate;
+
+    private Applicant applicant;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        applicant = new Applicant();
+        applicant.setId("1");
+        applicant.setFirstName("John");
+        applicant.setLastName("Doe");
+        applicant.setEmail("john@example.com");
+        applicant.setPhoneNumber("1234567890");
+        applicant.setPositionAppliedFor("Software Engineer");
+        applicant.setStatus(ApplicantStatus.APPLIED);
+        applicant.setExperience("5 years");
+        applicant.setApplicantId("Employee1");
+        applicant.setCreatedAt(new Date());
+    }
+
+    @Test
+    public void testGetPaginatedApplicants_ValidPagination() {
+        when(mongoTemplate.find(any(Query.class), eq(Applicant.class))).thenReturn(Collections.singletonList(applicant));
+        when(mongoTemplate.count(any(Query.class), eq(Applicant.class))).thenReturn(1L);
+
+        PaginatedApplicantResponse response = applicantServiceImpl.getPaginatedApplicants(
+                1, 10, null, null, null, null, null, null, null, "createdAt", "asc");
+
+        assertEquals(1, response.getApplicants().size());
+        assertEquals(1, response.getCurrentPage());
+        assertEquals(10, response.getPageSize());
+        assertEquals(1, response.getTotalRecords());
+        assertEquals(1, response.getTotalPages());
+    }
+
+    @Test
+    public void testGetPaginatedApplicants_NoResults() {
+        when(mongoTemplate.find(any(Query.class), eq(Applicant.class))).thenReturn(Collections.emptyList());
+        when(mongoTemplate.count(any(Query.class), eq(Applicant.class))).thenReturn(0L);
+
+        PaginatedApplicantResponse response = applicantServiceImpl.getPaginatedApplicants(
+                1, 10, null, null, null, null, null, null, null, "createdAt", "asc");
+
+        assertTrue(response.getApplicants().isEmpty());
+        assertEquals(1, response.getCurrentPage());
+        assertEquals(10, response.getPageSize());
+        assertEquals(0, response.getTotalRecords());
+        assertEquals(0, response.getTotalPages());
+    }
+    @Test
+    public void testGetPaginatedApplicants_WithFilters() {
+        when(mongoTemplate.find(any(Query.class), eq(Applicant.class))).thenReturn(Collections.singletonList(applicant));
+        when(mongoTemplate.count(any(Query.class), eq(Applicant.class))).thenReturn(1L);
+
+        PaginatedApplicantResponse response = applicantServiceImpl.getPaginatedApplicants(
+                1, 10, null, "John", null, null, null, null, null, "createdAt", "asc");
+
+        assertEquals(1, response.getApplicants().size());
+        assertEquals("John", response.getApplicants().get(0).getFirstName());
+    }
+
+    @Test
+    public void testGetPaginatedApplicants_WithApplicantIdFilter() {
+        when(mongoTemplate.find(any(Query.class), eq(Applicant.class))).thenReturn(Collections.singletonList(applicant));
+        when(mongoTemplate.count(any(Query.class), eq(Applicant.class))).thenReturn(1L);
+
+        PaginatedApplicantResponse response = applicantServiceImpl.getPaginatedApplicants(
+                1, 10, "Employee1", null, null, null, null, null, null, "createdAt", "asc");
+
+        assertEquals(1, response.getApplicants().size());
+        assertEquals("Employee1", response.getApplicants().get(0).getApplicantId());
+    }
+
+    @Test
+    public void testGetPaginatedApplicants_WithPositionAppliedForFilter() {
+        when(mongoTemplate.find(any(Query.class), eq(Applicant.class))).thenReturn(Collections.singletonList(applicant));
+        when(mongoTemplate.count(any(Query.class), eq(Applicant.class))).thenReturn(1L);
+
+        PaginatedApplicantResponse response = applicantServiceImpl.getPaginatedApplicants(
+                1, 10, null, null, "Software Engineer", null, null, null, null, "createdAt", "asc");
+
+        assertEquals(1, response.getApplicants().size());
+        assertEquals("Software Engineer", response.getApplicants().get(0).getPositionAppliedFor());
+    }
+
+    @Test
+    public void testGetPaginatedApplicants_WithStatusFilter() {
+        when(mongoTemplate.find(any(Query.class), eq(Applicant.class))).thenReturn(Arrays.asList(applicant));
+        when(mongoTemplate.count(any(Query.class), eq(Applicant.class))).thenReturn((long) Arrays.asList(applicant).size());
+
+        PaginatedApplicantResponse response = applicantServiceImpl.getPaginatedApplicants(
+                1, 10, null, null, null, ApplicantStatus.APPLIED, null, null, null, "createdAt", "asc");
+
+        assertEquals(1, response.getApplicants().size());
+        assertEquals(ApplicantStatus.APPLIED, response.getApplicants().get(0).getStatus());
+    }
+
+    @Test
+    public void testGetPaginatedApplicants_WithExperianceFilter(){
+        when(mongoTemplate.find(any(Query.class), eq(Applicant.class))).thenReturn(Arrays.asList(applicant));
+        when(mongoTemplate.count(any(Query.class), eq(Applicant.class))).thenReturn((long) Arrays.asList(applicant).size());
+
+        PaginatedApplicantResponse response = applicantServiceImpl.getPaginatedApplicants(
+                1, 10, null, null, null, null, "5 years", null, null, "createdAt", "asc");
+
+        assertEquals(1, response.getApplicants().size());
+        assertEquals("5 years",response.getApplicants().get(0).getExperience());
+    }
+
+    @Test
+    public void testGetPaginatedApplicants_WithDateFilters() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JANUARY, 1);
+        Date fromDate = cal.getTime();
+
+        cal.set(2024, Calendar.DECEMBER, 31);
+        Date toDate = cal.getTime();
+
+        cal.set(2024, Calendar.JUNE, 15);
+        Date createdAt = cal.getTime();
+        applicant.setCreatedAt(createdAt);
+
+        when(mongoTemplate.find(any(Query.class), eq(Applicant.class))).thenReturn(Collections.singletonList(applicant));
+        when(mongoTemplate.count(any(Query.class), eq(Applicant.class))).thenReturn(1L);
+
+        PaginatedApplicantResponse response = applicantServiceImpl.getPaginatedApplicants(
+                1, 10, null, null, null, null, null, fromDate, toDate, "createdAt", "asc");
+
+        assertFalse(response.getApplicants().isEmpty());
+        Date retrievedCreatedAt = response.getApplicants().get(0).getCreatedAt();
+
+        assertTrue(!retrievedCreatedAt.before(fromDate) && !retrievedCreatedAt.after(toDate));
+    }
+
+    @Test
+    public void testGetPaginatedApplicants_WithFromDateOnly() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.JANUARY, 1);
+        Date fromDate = cal.getTime();
+
+        when(mongoTemplate.find(any(Query.class), eq(Applicant.class))).thenReturn(Collections.singletonList(applicant));
+        when(mongoTemplate.count(any(Query.class), eq(Applicant.class))).thenReturn(1L);
+
+        PaginatedApplicantResponse response = applicantServiceImpl.getPaginatedApplicants(
+                1, 10, null, null, null, null, null, fromDate, null, "createdAt", "asc");
+
+        assertFalse(response.getApplicants().isEmpty());
+        Date createdAt = response.getApplicants().get(0).getCreatedAt();
+        assertTrue(createdAt.after(fromDate) || createdAt.equals(fromDate), "Applicant createdAt should be after or equal to fromDate");
+    }
+
+    @Test
+    public void testGetPaginatedApplicants_WithToDateOnly() {
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, Calendar.DECEMBER, 31);
+        Date toDate = cal.getTime();
+
+        cal.set(2024, Calendar.DECEMBER, 30);
+        Date createdAt = cal.getTime();
+        applicant.setCreatedAt(createdAt);
+
+
+        when(mongoTemplate.find(any(Query.class), eq(Applicant.class))).thenReturn(Collections.singletonList(applicant));
+        when(mongoTemplate.count(any(Query.class), eq(Applicant.class))).thenReturn(1L);
+
+        PaginatedApplicantResponse response = applicantServiceImpl.getPaginatedApplicants(
+                1, 10, null, null, null, null, null, null, toDate, "createdAt", "asc");
+
+        assertFalse(response.getApplicants().isEmpty());
+        Date retrievedCreatedAt = response.getApplicants().get(0).getCreatedAt();
+        assertTrue(retrievedCreatedAt.before(toDate) || retrievedCreatedAt.equals(toDate), "Applicant createdAt should be before or equal to toDate");
+    }
+
+}


### PR DESCRIPTION

This PR improved the List of Applicants API by adding pagination and sorting to enhance performance and optimize data retrieval.
Changes Made:
- Added pagination support using page and limit parameters to fetch data in smaller chunks.
- Implemented sorting functionality with sortBy and sortDirection for dynamic ordering of results.
- Applied filtering criteria for applicant details such as applicantId, firstName, positionAppliedFor, status, experience, and createdDate.
- Included metadata in the response, such as totalRecords and totalPages, to assist frontend integration.
- Set a default page size (10 applicants per page) and a maximum limit to prevent excessive data retrieval.