### PR TITLE
Fix issue in bulk payslip upload functionality

### DIFF
--- a/services/beeja-finance/src/main/java/com/beeja/api/financemanagementservice/serviceImpl/LoanServiceImpl.java
+++ b/services/beeja-finance/src/main/java/com/beeja/api/financemanagementservice/serviceImpl/LoanServiceImpl.java
@@ -3,13 +3,11 @@ package com.beeja.api.financemanagementservice.serviceImpl;
 import com.beeja.api.financemanagementservice.Utils.BuildErrorMessage;
 import com.beeja.api.financemanagementservice.Utils.Constants;
 import com.beeja.api.financemanagementservice.Utils.UserContext;
-import com.beeja.api.financemanagementservice.Utils.helpers.FileExtensionHelpers;
 import com.beeja.api.financemanagementservice.client.AccountClient;
 import com.beeja.api.financemanagementservice.enums.ErrorCode;
 import com.beeja.api.financemanagementservice.enums.ErrorType;
 import com.beeja.api.financemanagementservice.enums.LoanStatus;
 import com.beeja.api.financemanagementservice.exceptions.ResourceNotFoundException;
-import com.beeja.api.financemanagementservice.modals.File;
 import com.beeja.api.financemanagementservice.modals.Loan;
 import com.beeja.api.financemanagementservice.modals.clients.finance.OrganizationPattern;
 import com.beeja.api.financemanagementservice.repository.LoanRepository;
@@ -17,16 +15,23 @@ import com.beeja.api.financemanagementservice.requests.BulkPayslipRequest;
 import com.beeja.api.financemanagementservice.requests.PdfMultipartFile;
 import com.beeja.api.financemanagementservice.requests.SubmitLoanRequest;
 import com.beeja.api.financemanagementservice.service.LoanService;
+import com.beeja.api.financemanagementservice.requests.FileUploadRequest;
+import com.beeja.api.financemanagementservice.client.FileClient;
 import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -52,6 +57,8 @@ public class LoanServiceImpl implements LoanService {
 
   @Autowired
   AccountClient accountClient;
+
+  @Autowired FileClient fileClient;
 
   /**
    * Changes the status of a loan based on the provided loan ID.
@@ -190,32 +197,82 @@ public class LoanServiceImpl implements LoanService {
   /**
    * Uploads bulk payslips in a zip file asynchronously.
    *
-   * @param bulkPayslipRequest The request object containing bulk payslip details.
+   * @param bulkPayslipRequest  The request object containing bulk payslip details.
    * @param authorizationHeader Authorization header for API calls.
    * @throws Exception If an error occurs during bulk payslip upload.
    */
   @Override
-  public void uploadBulkPaySlips(BulkPayslipRequest bulkPayslipRequest, String authorizationHeader)
-      throws Exception {
-    MultipartFile file = bulkPayslipRequest.getZipFile();
-    List<MultipartFile> pdfFiles = new ArrayList<>();
-    File fileEntity = new File();
-    fileEntity.setFileSize(String.valueOf(file.getSize()));
-    fileEntity.setName(file.getName());
-    fileEntity.setFileFormat(
-        FileExtensionHelpers.getExtension(Objects.requireNonNull(file.getOriginalFilename())));
-    fileEntity.setEntityType(zipFile);
-    // Unzipping file
-    try (ZipInputStream zipInputStream = new ZipInputStream(file.getInputStream())) {
-      for (ZipEntry entry = zipInputStream.getNextEntry();
-          entry != null;
-          entry = zipInputStream.getNextEntry()) {
-        if (entry.getName().toLowerCase().endsWith(PDF)) {
-          pdfFiles.add(
-              new PdfMultipartFile(
-                  entry.getName(), entry.getName(), zipInputStream.readAllBytes()));
+  public void uploadBulkPaySlips(BulkPayslipRequest bulkPayslipRequest, String authorizationHeader) {
+    MultipartFile zipFile = bulkPayslipRequest.getZipFile();
+    List<String> successList = new ArrayList<>();
+    List<String> failureList = new ArrayList<>();
+
+    try (ZipInputStream zipInputStream = new ZipInputStream(zipFile.getInputStream())) {
+
+      for (ZipEntry entry = zipInputStream.getNextEntry(); entry != null; entry = zipInputStream.getNextEntry()) {
+        String fileName = entry.getName();
+
+        if (fileName == null || fileName.trim().isEmpty()) {
+          failureList.add("Unknown file with missing name.");
+          continue;
+        }
+
+        if (!fileName.toLowerCase().endsWith(".pdf")) {
+          failureList.add(fileName + " - Unsupported file type.");
+          continue;
+        }
+
+        try {
+          byte[] pdfBytes = zipInputStream.readAllBytes();
+          String employeeId = extractEmployeeIdFromPdf(pdfBytes);
+
+          if (employeeId == null || employeeId.isEmpty()) {
+            failureList.add(fileName + " - Employee ID not found.");
+            continue;
+          }
+
+          String finalFileName = employeeId + "_" + bulkPayslipRequest.getMonth() + "_" + bulkPayslipRequest.getYear() + ".pdf";
+
+          MultipartFile payslipFile = new PdfMultipartFile(finalFileName, finalFileName, pdfBytes);
+
+          FileUploadRequest fileUploadRequest = new FileUploadRequest();
+          fileUploadRequest.setFile(payslipFile);
+          fileUploadRequest.setName(finalFileName);
+          fileUploadRequest.setFileType("pdf");
+          fileUploadRequest.setEntityType("employee");
+          fileUploadRequest.setEntityId(employeeId);
+          fileUploadRequest.setDescription("Payslip for employee " + employeeId);
+
+          ResponseEntity<?> response = fileClient.uploadFile(fileUploadRequest, authorizationHeader);
+
+          successList.add(finalFileName + " - uploaded successfully.");
+        } catch (Exception e) {
+          failureList.add(fileName + " - Upload failed: " + e.getMessage());
+          log.warn("Failed to upload {}: {}", fileName, e.getMessage(), e);
         }
       }
+    } catch (IOException e) {
+      failureList.add("ZIP file could not be processed: " + e.getMessage());
+      log.warn("Failed to process zip file: {}", e.getMessage(), e);
     }
+
+    log.info("Payslip upload complete. Success: {}, Failures: {}", successList.size(), failureList.size());
+    successList.forEach(msg -> log.info("SUCCESS: " + msg));
+    failureList.forEach(msg -> log.warn("FAILURE: " + msg));
+  }
+
+
+  private String extractEmployeeIdFromPdf(byte[] pdfBytes) throws IOException {
+    try (PDDocument document = PDDocument.load(pdfBytes)) {
+      PDFTextStripper stripper = new PDFTextStripper();
+      String text = stripper.getText(document);
+
+      Pattern pattern = Pattern.compile("Employee ID\\s*[:\\-]?\\s*([A-Z]+\\d+)", Pattern.CASE_INSENSITIVE);
+      Matcher matcher = pattern.matcher(text);
+      if (matcher.find()) {
+        return matcher.group(1);
+      }
+    }
+    throw new RuntimeException("Employee ID not found in PDF");
   }
 }

--- a/services/beeja-finance/src/test/java/com/beeja/api/financemanagementservice/serviceImpl/BulkPayslipUploadTest.java
+++ b/services/beeja-finance/src/test/java/com/beeja/api/financemanagementservice/serviceImpl/BulkPayslipUploadTest.java
@@ -1,0 +1,199 @@
+package com.beeja.api.financemanagementservice.serviceImpl;
+
+import com.beeja.api.financemanagementservice.client.FileClient;
+import com.beeja.api.financemanagementservice.requests.BulkPayslipRequest;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class BulkPayslipUploadTest {
+
+    @InjectMocks
+    private LoanServiceImpl loanService;
+
+    @Mock
+    private FileClient fileClient;
+
+    @Mock
+    private MultipartFile zipFile;
+
+    private final String authorizationHeader = "Bearer test-token";
+
+    @Test
+    void testValidPdf_uploadSuccess() throws Exception {
+        // 1. Create dummy PDF with employee ID
+        byte[] pdfBytes = createDummyPdf("Employee ID: EMP12345");
+
+        // 2. Zip the dummy PDF
+        byte[] zipBytes = createZipBytes(Map.of("payslip1.pdf", pdfBytes));
+        when(zipFile.getInputStream()).thenReturn(new ByteArrayInputStream(zipBytes));
+
+        // 3. Prepare request
+        BulkPayslipRequest request = new BulkPayslipRequest();
+        request.setZipFile(zipFile);
+        request.setMonth("April");
+        request.setYear("2025");
+
+        // 4. Mock uploadFile response
+        when(fileClient.uploadFile(any(), eq(authorizationHeader)))
+                .thenReturn(ResponseEntity.ok().build());
+
+        // 5. Call the method
+        loanService.uploadBulkPaySlips(request, authorizationHeader);
+
+        // 6. Verify fileClient was used once
+        verify(fileClient, times(1)).uploadFile(any(), eq(authorizationHeader));
+    }
+
+    // Helper to create a simple PDF with a line of text
+    private byte[] createDummyPdf(String text) throws IOException {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             PDDocument document = new PDDocument()) {
+
+            PDPage page = new PDPage();
+            document.addPage(page);
+
+            try (PDPageContentStream contentStream = new PDPageContentStream(document, page)) {
+                contentStream.beginText();
+                contentStream.setFont(PDType1Font.HELVETICA, 12);
+                contentStream.newLineAtOffset(100, 700);
+                contentStream.showText(text);
+                contentStream.endText();
+            }
+
+            document.save(outputStream);
+            return outputStream.toByteArray();
+        }
+    }
+    @Test
+    void testMissingFileName_skipped() throws Exception {
+        byte[] zipBytes = createZipBytes(Map.of("", createDummyPdf("Employee ID: EMP12345")));
+        when(zipFile.getInputStream()).thenReturn(new ByteArrayInputStream(zipBytes));
+
+        BulkPayslipRequest request = new BulkPayslipRequest();
+        request.setZipFile(zipFile);
+        request.setMonth("April");
+        request.setYear("2025");
+
+        loanService.uploadBulkPaySlips(request, authorizationHeader);
+        // No exception is thrown, log should warn about missing filename
+    }
+
+    @Test
+    void testUnsupportedFileType_skipped() throws Exception {
+        byte[] fakeTxt = "Just text".getBytes();
+        byte[] zipBytes = createZipBytes(Map.of("notes.txt", fakeTxt));
+        when(zipFile.getInputStream()).thenReturn(new ByteArrayInputStream(zipBytes));
+
+        BulkPayslipRequest request = new BulkPayslipRequest();
+        request.setZipFile(zipFile);
+        request.setMonth("April");
+        request.setYear("2025");
+
+        loanService.uploadBulkPaySlips(request, authorizationHeader);
+        // Should skip .txt file as unsupported
+    }
+
+    @Test
+    void testMissingEmployeeId_skipped() throws Exception {
+        byte[] pdfBytes = createDummyPdf("This PDF has no employee ID.");
+        byte[] zipBytes = createZipBytes(Map.of("payslip.pdf", pdfBytes));
+        when(zipFile.getInputStream()).thenReturn(new ByteArrayInputStream(zipBytes));
+
+        BulkPayslipRequest request = new BulkPayslipRequest();
+        request.setZipFile(zipFile);
+        request.setMonth("April");
+        request.setYear("2025");
+
+        loanService.uploadBulkPaySlips(request, authorizationHeader);
+        // Should log "Employee ID not found"
+    }
+
+    @Test
+    void testFileUploadFailure_logged() throws Exception {
+        byte[] pdfBytes = createDummyPdf("Employee ID: EMP99999");
+        byte[] zipBytes = createZipBytes(Map.of("failme.pdf", pdfBytes));
+        when(zipFile.getInputStream()).thenReturn(new ByteArrayInputStream(zipBytes));
+
+        doThrow(new RuntimeException("Simulated upload failure"))
+                .when(fileClient).uploadFile(any(), eq(authorizationHeader));
+
+        BulkPayslipRequest request = new BulkPayslipRequest();
+        request.setZipFile(zipFile);
+        request.setMonth("April");
+        request.setYear("2025");
+
+        loanService.uploadBulkPaySlips(request, authorizationHeader);
+        // Logs should show the failure
+    }
+
+    @Test
+    void testInvalidZipFile_logsFailure() throws Exception {
+        // Send corrupted zip content
+        byte[] invalidZip = "not a real zip".getBytes();
+        when(zipFile.getInputStream()).thenReturn(new ByteArrayInputStream(invalidZip));
+
+        BulkPayslipRequest request = new BulkPayslipRequest();
+        request.setZipFile(zipFile);
+        request.setMonth("April");
+        request.setYear("2025");
+
+        loanService.uploadBulkPaySlips(request, authorizationHeader);
+        // Should log "ZIP file could not be processed"
+    }
+    @Test
+    void testCorruptedZipFile_triggersIOException() throws Exception {
+        byte[] invalidZip = "not-a-valid-zip".getBytes();
+
+        // Use a real MockMultipartFile here (no unnecessary stub)
+        MockMultipartFile brokenZip = new MockMultipartFile(
+                "zipFile",
+                "broken.zip",
+                "application/zip",
+                invalidZip
+        );
+
+        BulkPayslipRequest request = new BulkPayslipRequest();
+        request.setZipFile(brokenZip);
+        request.setMonth("April");
+        request.setYear("2025");
+
+        loanService.uploadBulkPaySlips(request, authorizationHeader);
+
+        // No upload should happen
+        verify(fileClient, never()).uploadFile(any(), any());
+    }
+
+    // Helper to zip a single or multiple files
+    private byte[] createZipBytes(Map<String, byte[]> files) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            for (Map.Entry<String, byte[]> entry : files.entrySet()) {
+                ZipEntry zipEntry = new ZipEntry(entry.getKey());
+                zos.putNextEntry(zipEntry);
+                zos.write(entry.getValue());
+                zos.closeEntry();
+            }
+        }
+        return baos.toByteArray();
+    }
+}


### PR DESCRIPTION
This PR introduces improvements to the bulk payslip upload functionality.

- Validated each file inside the ZIP for ( Missing file name, Unsupported file type (non-PDF), Missing or unrecognized Employee ID)
- Handled corrupted or unreadable ZIP files using proper exception handling.
- Ensured individual file failures don’t stop the overall process.
- Added clear success and failure logs for each file.
- Added JUnit test cases for the uploadBulkPaySlips method.