### PR TITLE
fix:fixed Availability Filter

### DIFF
--- a/web/src/screens/InventoryManagement.screen.tsx
+++ b/web/src/screens/InventoryManagement.screen.tsx
@@ -110,7 +110,7 @@ const InventoryManagement = () => {
         queryParams.push(
           `device=${encodeURIComponent(deviceFilter.toUpperCase())}`
         );
-      if (availabilityFilter != null && availabilityFilter != '-')
+      if (availabilityFilter != null && availabilityFilter != '-' && availabilityFilter != 'availability')
         queryParams.push(
           `availability=${encodeURIComponent(availabilityFilter.toUpperCase())}`
         );


### PR DESCRIPTION
- Issue:
The availability filter in the Inventory Management screen caused a continuous loading state when toggled or reset.

- Root Cause:
The filter included a default value ("availability") in the API query, which led to incorrect filtering and prevented data fetching.

- Fix:
Added a condition to exclude the default "availability" value from the query.