### PR TITLE
fix:Remove Editable Appearance

### DIFF
--- a/web/src/components/reusableComponents/MyProfileGeneralTabContent.component.tsx
+++ b/web/src/components/reusableComponents/MyProfileGeneralTabContent.component.tsx
@@ -580,6 +580,7 @@ export const GeneralDetailsTab = ({
                           </>
                         ) : (
                           <InlineInput
+                          disabled={label === 'Employee Id'}
                             type={
                               label === 'Date of Birth' ||
                               label === 'Joining Date'


### PR DESCRIPTION
This PR Introduced:
-  This enhancement addresses a UX issue where the Employee ID field in the "Job" section appeared editable, causing confusion among users.
- Although the field was not meant to be modified, its editable appearance implied otherwise.