### PR TITLE
fix : Organization Defaults Update API Failure

### DIFF
--- a/services/beeja-accounts/src/main/java/com/beeja/api/accounts/mongo/OrgDefaultsChecks.java
+++ b/services/beeja-accounts/src/main/java/com/beeja/api/accounts/mongo/OrgDefaultsChecks.java
@@ -1,0 +1,62 @@
+package com.beeja.api.accounts.mongo;
+
+import com.beeja.api.accounts.model.Organization.OrgDefaults;
+import com.beeja.api.accounts.model.Organization.employeeSettings.OrgValues;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.scheduling.annotation.Async;
+
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+
+@Configuration
+@Slf4j
+public class OrgDefaultsChecks {
+    private final MongoTemplate mongoTemplate;
+
+    public OrgDefaultsChecks(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @PostConstruct
+    public void initRemoveDuplicatesORGDefaults(){
+        removeExistingDuplicates();
+    }
+
+    @Async
+    public void removeExistingDuplicates(){
+        try{
+
+            List<OrgDefaults> orgDefaultsList =  mongoTemplate.findAll(OrgDefaults.class);
+            for(OrgDefaults orgDefaults: orgDefaultsList){
+
+                Set<OrgValues> orginalValues = orgDefaults.getValues();
+                Set<OrgValues> updatedValues = removeDuplicates(orginalValues);
+
+                if(!updatedValues.equals(orginalValues)){
+                    orgDefaults.setValues(updatedValues);
+                    mongoTemplate.save(orgDefaults);
+                }
+            }
+        }
+        catch (Exception e){
+            log.error("Error removing duplicate values inside OrgDefaults", e);
+        }
+    }
+
+    private Set<OrgValues> removeDuplicates(Set<OrgValues> orginalValues) {
+        Set<String> seenValues = new HashSet<>();
+        Set<OrgValues> filteredValues = new HashSet<>();
+        for (OrgValues value : orginalValues) {
+            if (value.getValue() != null && seenValues.add(value.getValue().toLowerCase())) {
+                filteredValues.add(value);
+            }
+        }
+        return filteredValues;
+    }
+}

--- a/services/beeja-accounts/src/main/java/com/beeja/api/accounts/serviceImpl/OrganizationServiceImpl.java
+++ b/services/beeja-accounts/src/main/java/com/beeja/api/accounts/serviceImpl/OrganizationServiceImpl.java
@@ -429,6 +429,7 @@ public class OrganizationServiceImpl implements OrganizationService {
 
   private boolean hasDuplicateValues(Set<OrgValues> values) {
     return values.stream()
+            .filter(v -> v.getValue() != null)
             .map(v -> v.getValue().toLowerCase())
             .collect(Collectors.toSet())
             .size() < values.size();


### PR DESCRIPTION
This PR addresses an issue where the organization update API was failing due to duplicate values in OrgDefaults.
To resolve this, I implemented the following:
- On application startup (@PostConstruct),all OrgDefaults records were scanned.
- Duplicate OrgValues (case-insensitive) were removed.
- Only unique values were retained and saved back to the database.
- The logic was implemented asynchronously (@Async) to avoid blocking the startup process.