### PR TITLE
Fix:Resolved Fix Issue Preventing Updates to Existing Device Details …

### DIFF
--- a/services/beeja-finance/src/main/java/com/beeja/api/financemanagementservice/enums/Device.java
+++ b/services/beeja-finance/src/main/java/com/beeja/api/financemanagementservice/enums/Device.java
@@ -1,5 +1,7 @@
 package com.beeja.api.financemanagementservice.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 
 @Getter
@@ -24,5 +26,19 @@ public enum Device {
 
   Device(String displayName) {
     this.displayName = displayName;
+  }
+  @JsonValue
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  @JsonCreator
+  public static Device fromValue(String value) {
+    for (Device device : Device.values()) {
+      if (device.displayName.equalsIgnoreCase(value)) {
+        return device;
+      }
+    }
+    throw new IllegalArgumentException("Unknown device: " + value);
   }
 }


### PR DESCRIPTION
- Resolved an issue where updates to existing device details were not being applied correctly from both the form submission and the preview view.
- The root cause was due to missing binding logic and state updates, which have now been corrected. 
- This fix ensures that users can seamlessly update device details from either interface.