### PR TITLE
Generate Postman Collections Wherever Missing 

### DIFF
--- a/services/beeja-accounts/src/main/resources/static/Account_service_postman_collections.json
+++ b/services/beeja-accounts/src/main/resources/static/Account_service_postman_collections.json
@@ -1,10 +1,9 @@
 {
 	"info": {
-		"_postman_id": "822a52aa-0d32-47cf-b59b-b7a9a7e99f7a",
+		"_postman_id": "4bc35ca3-46f2-4650-9900-450a7f169a0a",
 		"name": "Account Service Collection",
-		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
-		"_exporter_id": "32741508",
-		"_collection_link": "https://beeja-v2.postman.co/workspace/Beeja-Developer-Workspace~030575b9-2bb0-4d3a-9de7-da77fa084a64/collection/32741508-822a52aa-0d32-47cf-b59b-b7a9a7e99f7a?action=share&source=collection_link&creator=32741508"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "43003168"
 	},
 	"item": [
 		{
@@ -15,7 +14,17 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"url": "http://localhost:8000/accounts/v1/features"
+						"url": {
+							"raw": "{{port}}/accounts/v1/features",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"features"
+							]
+						}
 					},
 					"response": []
 				},
@@ -33,7 +42,18 @@
 								}
 							}
 						},
-						"url": "http://localhost:8000/accounts/v1/features/6622bd1aed44325fe2ca89cf"
+						"url": {
+							"raw": "{{port}}/accounts/v1/features/{{organizationId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"features",
+								"{{organizationId}}"
+							]
+						}
 					},
 					"response": []
 				}
@@ -47,7 +67,18 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"url": "http://localhost:8000/accounts/v1/organizations/6622bd1aed44325fe2ca89cf"
+						"url": {
+							"raw": "{{port}}/accounts/v1/organizations/{{organizationId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"organizations",
+								"{{organizationId}}"
+							]
+						}
 					},
 					"response": []
 				},
@@ -56,7 +87,19 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"url": "http://localhost:8000/accounts/v1/organizations/6622bd1aed44325fe2ca89cf/employees"
+						"url": {
+							"raw": "{{port}}/accounts/v1/organizations/{{organizationId}}/employees",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"organizations",
+								"{{organizationId}}",
+								"employees"
+							]
+						}
 					},
 					"response": []
 				},
@@ -65,7 +108,18 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"url": "http://localhost:8000/accounts/v1/organizations/6622bd1aed44325fe2ca89cf/employees"
+						"url": {
+							"raw": "{{port}}/accounts/v1/organizations/logo",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"organizations",
+								"logo"
+							]
+						}
 					},
 					"response": []
 				},
@@ -74,7 +128,18 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"url": "http://localhost:8000/accounts/v1/organizations/6622bd1aed44325fe2ca89cf"
+						"url": {
+							"raw": "{{port}}/accounts/v1/organizations/{{organizationId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"organizations",
+								"{{organizationId}}"
+							]
+						}
 					},
 					"response": []
 				},
@@ -92,7 +157,18 @@
 								}
 							}
 						},
-						"url": "http://localhost:8000/accounts/v1/organizations/update-values"
+						"url": {
+							"raw": "{{port}}/accounts/v1/organizations/update-values",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"organizations",
+								"update-values"
+							]
+						}
 					},
 					"response": []
 				},
@@ -113,7 +189,77 @@
 								}
 							}
 						},
-						"url": "http://localhost:8000/accounts/v1/organizations/values/employeeTypes"
+						"url": {
+							"raw": "{{port}}/accounts/v1/organizations/values/employeeTypes",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"organizations",
+								"values",
+								"employeeTypes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "update Organization by patch method",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"subscriptionId\": \"12345678\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/accounts/v1/organizations/{{organizationId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"organizations",
+								"{{organizationId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Generate Organization Defaults",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/accounts/v1/organizations/generate-defaults",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"organizations",
+								"generate-defaults"
+							]
+						}
 					},
 					"response": []
 				}
@@ -127,7 +273,18 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"url": "http://localhost:8000/accounts/v1/organization/patterns/{patternTypes}"
+						"url": {
+							"raw": "{{port}}/v1/organization/patterns/{{patternType}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"v1",
+								"organization",
+								"patterns",
+								"{{patternType}}"
+							]
+						}
 					},
 					"response": []
 				},
@@ -145,7 +302,18 @@
 								}
 							}
 						},
-						"url": "http://localhost:8000/accounts/v1/organization/patterns"
+						"url": {
+							"raw": "{{port}}/accounts/v1/organization/patterns",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"organization",
+								"patterns"
+							]
+						}
 					},
 					"response": []
 				},
@@ -164,12 +332,10 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:8000/accounts/v1/organization/patterns/update-status?patternId=6752c80748a9356d07598552&patternType=EMPLOYEE_ID_PATTERN",
-							"protocol": "http",
+							"raw": "{{port}}/accounts/v1/organization/patterns/update-status?patternId={{patternId}}&patternType={{patternType}}",
 							"host": [
-								"localhost"
+								"{{port}}"
 							],
-							"port": "8000",
 							"path": [
 								"accounts",
 								"v1",
@@ -180,11 +346,11 @@
 							"query": [
 								{
 									"key": "patternId",
-									"value": "6752c80748a9356d07598552"
+									"value": "{{patternId}}"
 								},
 								{
 									"key": "patternType",
-									"value": "EMPLOYEE_ID_PATTERN"
+									"value": "{{patternType}}"
 								}
 							]
 						}
@@ -192,11 +358,51 @@
 					"response": []
 				},
 				{
-					"name": "Delete PAttern",
+					"name": "Delete Pattern",
 					"request": {
 						"method": "DELETE",
 						"header": [],
-						"url": "http://localhost:8000/accounts/v1/organization/patterns/{patternId}/{patternType}"
+						"url": {
+							"raw": "{{port}}/accounts/v1/organization/patterns/{{patternId}}}/{{patternType}}rnType}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"organization",
+								"patterns",
+								"{{patternId}}}",
+								"{{patternType}}rnType}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Active Pattern By Type",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/accounts/v1/organization/patterns/active?patternType={{patternType}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"organization",
+								"patterns",
+								"active"
+							],
+							"query": [
+								{
+									"key": "patternType",
+									"value": "{{patternType}}"
+								}
+							]
+						}
 					},
 					"response": []
 				}
@@ -219,14 +425,24 @@
 								}
 							}
 						},
-						"url": "http://localhost:8000/accounts/v1/roles"
+						"url": {
+							"raw": "{{port}}/accounts/v1/roles",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"roles"
+							]
+						}
 					},
 					"response": []
 				},
 				{
 					"name": "Update Role By Id",
 					"request": {
-						"method": "POST",
+						"method": "PUT",
 						"header": [],
 						"body": {
 							"mode": "raw",
@@ -237,7 +453,18 @@
 								}
 							}
 						},
-						"url": "http://localhost:8000/accounts/v1/roles/6762a5d4d7404c27b753471c"
+						"url": {
+							"raw": "{{port}}/accounts/v1/roles/{{employeeId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"roles",
+								"{{employeeId}}"
+							]
+						}
 					},
 					"response": []
 				},
@@ -258,7 +485,17 @@
 								}
 							}
 						},
-						"url": "http://localhost:8000/accounts/v1/roles"
+						"url": {
+							"raw": "{{port}}/accounts/v1/roles",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"roles"
+							]
+						}
 					},
 					"response": []
 				},
@@ -276,233 +513,385 @@
 								}
 							}
 						},
-						"url": "http://localhost:8000/accounts/v1/roles/6762a5d4d7404c27b753471c"
+						"url": {
+							"raw": "{{port}}/accounts/v1/roles/{{employeeId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"roles",
+								"{{employeeId}}"
+							]
+						}
 					},
 					"response": []
 				}
 			]
 		},
 		{
-			"name": "New Request",
-			"request": {
-				"method": "GET",
-				"header": []
-			},
-			"response": []
-		},
-		{
-			"name": "Post Employee",
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n  \"firstName\": \"TEST123\",\n  \"lastName\": \"Chandar\",\n  \"email\": \"poorna123@gmail.com\",\n  \"employmentType\": \"Full-Time Employees\"\n}\n",
-					"options": {
-						"raw": {
-							"language": "json"
+			"name": "Employee",
+			"item": [
+				{
+					"name": "Get All Employees",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "accessToken",
+								"value": "Bearer ya29.a0AfB_byAcwxp_MxSrtMFHNCUVdtxmEK00Wqe2zhqCFmu7ouNDNbJsKKRlhTCqMRnkLNtHuMkquewdtqPMwBG0HLqPMWws_BMkF7S_zPLAj-DA5at8pTg8_oAEp0Q5isv1kCx7MdUEd78v03GN42Z3oEszgDp3MI8dt8MaCgYKAYUSARESFQGOcNnCNr8epVfGp-u0pcbpOO4sHQ0170",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"url": {
+							"raw": "{{port}}/accounts/v1/users",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"users"
+							]
 						}
-					}
+					},
+					"response": []
 				},
-				"url": "http://localhost:8000/accounts/v1/users"
-			},
-			"response": []
-		},
-		{
-			"name": "Get All Employees",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "accessToken",
-						"value": "Bearer ya29.a0AfB_byAcwxp_MxSrtMFHNCUVdtxmEK00Wqe2zhqCFmu7ouNDNbJsKKRlhTCqMRnkLNtHuMkquewdtqPMwBG0HLqPMWws_BMkF7S_zPLAj-DA5at8pTg8_oAEp0Q5isv1kCx7MdUEd78v03GN42Z3oEszgDp3MI8dt8MaCgYKAYUSARESFQGOcNnCNr8epVfGp-u0pcbpOO4sHQ0170",
-						"type": "text",
-						"disabled": true
-					}
-				],
-				"url": "http://localhost:8000/accounts/v1/users"
-			},
-			"response": []
-		},
-		{
-			"name": "Get All Employees based on Permission",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "accessToken",
-						"value": "Bearer ya29.a0AfB_byAcwxp_MxSrtMFHNCUVdtxmEK00Wqe2zhqCFmu7ouNDNbJsKKRlhTCqMRnkLNtHuMkquewdtqPMwBG0HLqPMWws_BMkF7S_zPLAj-DA5at8pTg8_oAEp0Q5isv1kCx7MdUEd78v03GN42Z3oEszgDp3MI8dt8MaCgYKAYUSARESFQGOcNnCNr8epVfGp-u0pcbpOO4sHQ0170",
-						"type": "text",
-						"disabled": true
-					}
-				],
-				"url": "http://localhost:8000/accounts/v1/users/permissions/REMP"
-			},
-			"response": []
-		},
-		{
-			"name": "Get All Employees based on Employee Id List",
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "accessToken",
-						"value": "Bearer ya29.a0AfB_byAcwxp_MxSrtMFHNCUVdtxmEK00Wqe2zhqCFmu7ouNDNbJsKKRlhTCqMRnkLNtHuMkquewdtqPMwBG0HLqPMWws_BMkF7S_zPLAj-DA5at8pTg8_oAEp0Q5isv1kCx7MdUEd78v03GN42Z3oEszgDp3MI8dt8MaCgYKAYUSARESFQGOcNnCNr8epVfGp-u0pcbpOO4sHQ0170",
-						"type": "text",
-						"disabled": true
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"roles\": [\"TAC0063\"]\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+				{
+					"name": "Post Employee",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"firstName\": \"TEST123\",\n  \"lastName\": \"Chandar\",\n  \"email\": \"poorna123@gmail.com\",\n  \"employmentType\": \"Full-Time Employees\"\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/accounts/v1/users",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"users"
+							]
 						}
-					}
+					},
+					"response": []
 				},
-				"url": "http://localhost:8000/accounts/v1/users/emp-ids"
-			},
-			"response": []
-		},
-		{
-			"name": "Check employee has permission or not",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "accessToken",
-						"value": "Bearer ya29.a0AfB_byAcwxp_MxSrtMFHNCUVdtxmEK00Wqe2zhqCFmu7ouNDNbJsKKRlhTCqMRnkLNtHuMkquewdtqPMwBG0HLqPMWws_BMkF7S_zPLAj-DA5at8pTg8_oAEp0Q5isv1kCx7MdUEd78v03GN42Z3oEszgDp3MI8dt8MaCgYKAYUSARESFQGOcNnCNr8epVfGp-u0pcbpOO4sHQ0170",
-						"type": "text",
-						"disabled": true
-					}
-				],
-				"url": "http://localhost:8000/accounts/v1/users/{EMPLOYEE_ID}/exists/{PERMISSION}"
-			},
-			"response": []
-		},
-		{
-			"name": "Get Employee Count",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "GET",
-				"header": [
-					{
-						"key": "accessToken",
-						"value": "Bearer ya29.a0AfB_byAcwxp_MxSrtMFHNCUVdtxmEK00Wqe2zhqCFmu7ouNDNbJsKKRlhTCqMRnkLNtHuMkquewdtqPMwBG0HLqPMWws_BMkF7S_zPLAj-DA5at8pTg8_oAEp0Q5isv1kCx7MdUEd78v03GN42Z3oEszgDp3MI8dt8MaCgYKAYUSARESFQGOcNnCNr8epVfGp-u0pcbpOO4sHQ0170",
-						"type": "text",
-						"disabled": true
-					}
-				],
-				"url": "http://localhost:8000/accounts/v1/users/count"
-			},
-			"response": []
-		},
-		{
-			"name": "Get Employee By EmployeeID",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": "http://localhost:8000/accounts/v1/users/TAC0063"
-			},
-			"response": []
-		},
-		{
-			"name": "Get Employee By Email",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": "http://localhost:8000/accounts/v1/users/email/ravikiranbalemla5@gmail.com"
-			},
-			"response": []
-		},
-		{
-			"name": "Check Employee Exist with Email",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": "http://localhost:8000/accounts/v1/users/email/ravikiranbalemla5@gmail.com"
-			},
-			"response": []
-		},
-		{
-			"name": "Get Employee ME",
-			"request": {
-				"auth": {
-					"type": "noauth"
-				},
-				"method": "GET",
-				"header": [],
-				"url": "http://localhost:8000/accounts/v1/users/me"
-			},
-			"response": []
-		},
-		{
-			"name": "Change Status of Emp",
-			"request": {
-				"method": "PUT",
-				"header": []
-			},
-			"response": []
-		},
-		{
-			"name": "Get All Employees by permission",
-			"request": {
-				"method": "GET",
-				"header": []
-			},
-			"response": []
-		},
-		{
-			"name": "Change Status of Emp dev",
-			"request": {
-				"method": "PUT",
-				"header": []
-			},
-			"response": []
-		},
-		{
-			"name": "Update Employee using Emp Id",
-			"request": {
-				"method": "PUT",
-				"header": []
-			},
-			"response": []
-		},
-		{
-			"name": "Update Employee using Emp Id Copy",
-			"request": {
-				"method": "PUT",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"currentPassword\": \"asasakljsdf\",\n    \"newPassword\": \"qwerty123\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+				{
+					"name": "Get All Employees based on Permission",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "accessToken",
+								"value": "Bearer ya29.a0AfB_byAcwxp_MxSrtMFHNCUVdtxmEK00Wqe2zhqCFmu7ouNDNbJsKKRlhTCqMRnkLNtHuMkquewdtqPMwBG0HLqPMWws_BMkF7S_zPLAj-DA5at8pTg8_oAEp0Q5isv1kCx7MdUEd78v03GN42Z3oEszgDp3MI8dt8MaCgYKAYUSARESFQGOcNnCNr8epVfGp-u0pcbpOO4sHQ0170",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"url": {
+							"raw": "{{port}}/accounts/v1/users/permissions/{{permission }}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"users",
+								"permissions",
+								"{{permission }}"
+							]
 						}
-					}
+					},
+					"response": []
 				},
-				"url": "http://localhost:8000/accounts/v1/users/change-email-password"
-			},
-			"response": []
+				{
+					"name": "Check employee has permission or not",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "accessToken",
+								"value": "Bearer ya29.a0AfB_byAcwxp_MxSrtMFHNCUVdtxmEK00Wqe2zhqCFmu7ouNDNbJsKKRlhTCqMRnkLNtHuMkquewdtqPMwBG0HLqPMWws_BMkF7S_zPLAj-DA5at8pTg8_oAEp0Q5isv1kCx7MdUEd78v03GN42Z3oEszgDp3MI8dt8MaCgYKAYUSARESFQGOcNnCNr8epVfGp-u0pcbpOO4sHQ0170",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"url": {
+							"raw": "{{port}}/accounts/v1/users/{{employeeId}}/exists/{{permission }}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"users",
+								"{{employeeId}}",
+								"exists",
+								"{{permission }}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get All Employees based on Employee Id List",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "accessToken",
+								"value": "Bearer ya29.a0AfB_byAcwxp_MxSrtMFHNCUVdtxmEK00Wqe2zhqCFmu7ouNDNbJsKKRlhTCqMRnkLNtHuMkquewdtqPMwBG0HLqPMWws_BMkF7S_zPLAj-DA5at8pTg8_oAEp0Q5isv1kCx7MdUEd78v03GN42Z3oEszgDp3MI8dt8MaCgYKAYUSARESFQGOcNnCNr8epVfGp-u0pcbpOO4sHQ0170",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"roles\": [\"TAC0063\"]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/accounts/v1/users/{{emp-ids}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"users",
+								"{{emp-ids}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Employee Count",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "accessToken",
+								"value": "Bearer ya29.a0AfB_byAcwxp_MxSrtMFHNCUVdtxmEK00Wqe2zhqCFmu7ouNDNbJsKKRlhTCqMRnkLNtHuMkquewdtqPMwBG0HLqPMWws_BMkF7S_zPLAj-DA5at8pTg8_oAEp0Q5isv1kCx7MdUEd78v03GN42Z3oEszgDp3MI8dt8MaCgYKAYUSARESFQGOcNnCNr8epVfGp-u0pcbpOO4sHQ0170",
+								"type": "text",
+								"disabled": true
+							}
+						],
+						"url": {
+							"raw": "{{port}}/accounts/v1/users/count",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"users",
+								"count"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Employee By EmployeeID",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/accounts/v1/users/{{employeeId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"users",
+								"{{employeeId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Employee By Email",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/accounts/v1/users/email/{{email}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"users",
+								"email",
+								"{{email}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Check Employee Exist with Email",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/accounts/v1/users/email/{{email}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"users",
+								"email",
+								"{{email}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Employee ME",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/accounts/v1/users/me",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"users",
+								"me"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Change Status of Emp",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/accounts/v1/users/{{employeeId}}/status",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"users",
+								"{{employeeId}}",
+								"status"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "update User Roles By EmployeeId",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/accounts/v1/user//permissions/{{permission }}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"user",
+								"",
+								"permissions",
+								"{{permission }}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update Employee using Emp Id Copy",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"currentPassword\": \"asasakljsdf\",\n    \"newPassword\": \"qwerty123\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/accounts/v1/users/change-email-password",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"accounts",
+								"v1",
+								"users",
+								"change-email-password"
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		}
 	]
 }

--- a/services/beeja-employee-management/src/main/resources/postman/EmployeeService.postman_collection.json
+++ b/services/beeja-employee-management/src/main/resources/postman/EmployeeService.postman_collection.json
@@ -1,72 +1,308 @@
 {
 	"info": {
-		"_postman_id": "f218b62d-b717-4edd-a404-784a616e7257",
+		"_postman_id": "d0a6938e-e936-4b94-bd70-91b96bdef4d0",
 		"name": "EmployeeService",
-		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
-		"_exporter_id": "30821906"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "43003168"
 	},
 	"item": [
 		{
-			"name": "HelloWorld",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": "http://localhost:8000/employees/v1"
-			},
-			"response": []
-		},
-		{
-			"name": "GetAllEmployees",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": "http://localhost:8000/employees/v1/users"
-			},
-			"response": []
-		},
-		{
-			"name": "GetEmployeeByEmpId",
-			"request": {
-				"method": "GET",
-				"header": []
-			},
-			"response": []
-		},
-		{
-			"name": "CreateEmployee",
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+			"name": "Files",
+			"item": [
+				{
+					"name": "Get All Files Of EntityId",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/employees/v1/files/{{entityId}}?page=2&size=5",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"employees",
+								"v1",
+								"files",
+								"{{entityId}}"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "2"
+								},
+								{
+									"key": "size",
+									"value": "5"
+								}
+							]
 						}
-					}
+					},
+					"response": []
 				},
-				"url": "http://localhost:8000/employees/v1/users"
-			},
-			"response": []
+				{
+					"name": "Upload File",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/employees/v1/files",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"employees",
+								"v1",
+								"files"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Download File",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/employees/v1/files/download/{{fileId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"employees",
+								"v1",
+								"files",
+								"download",
+								"{{fileId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete File Of Employee",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/employees/v1/files/{{fileId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"employees",
+								"v1",
+								"files",
+								"{{fileId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update File By FileId",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"Updated File Name\",\n  \"fileType\": \"document\",\n  \"fileFormat\": \"pdf\",\n  \"fileSize\": \"2MB\",\n  \"entityId\": \"entity789\",\n  \"entityType\": \"invoice\",\n  \"description\": \"Updated file description\",\n  \"organizationId\": \"org456\",\n  \"createdBy\": \"user123\"}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/employees/v1/files/{{fileId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"employees",
+								"v1",
+								"files",
+								"{{fileId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Upload Or Update Profile Pic",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/employees/v1/files/profile-pic",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"employees",
+								"v1",
+								"files",
+								"profile-pic"
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		},
 		{
-			"name": "UpdateEmployee",
-			"request": {
-				"method": "PUT",
-				"header": [],
-				"url": "http://localhost:8000/employees/v1/users/TAC0063"
-			},
-			"response": []
-		},
-		{
-			"name": "DeleteAllEmployeesByOrgId",
-			"request": {
-				"method": "DELETE",
-				"header": [],
-				"url": "http://localhost:8000/employees/v1/users/organizations/654b0d9d355b9f0029b7733c"
-			},
-			"response": []
+			"name": "Employee",
+			"item": [
+				{
+					"name": "GetAllEmployees",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/employees/v1/users",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"employees",
+								"v1",
+								"users"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "CreateEmployee",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/employees/v1/users",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"employees",
+								"v1",
+								"users"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "UpdateEmployee",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/employees/v1/users/{{employeeId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"employees",
+								"v1",
+								"users",
+								"{{employeeId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GetEmployeeByEmpId",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/employees/v1/users/{{employeeId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"employees",
+								"v1",
+								"users",
+								"{{employeeId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "DeleteAllEmployeesByOrgId",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/employees/v1/users/organizations/{{organizationId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"employees",
+								"v1",
+								"users",
+								"organizations",
+								"{{organizationId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "update Kyc Details",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/employees/v1/users/{{employeeId}}/kyc",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"employees",
+								"v1",
+								"users",
+								"{{employeeId}}",
+								"kyc"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Employee Values",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/employees/v1/users/employee-values",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"employees",
+								"v1",
+								"users",
+								"employee-values"
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		}
 	]
 }

--- a/services/beeja-expense/src/main/resources/postman/ExpenseService.postman_collection.json
+++ b/services/beeja-expense/src/main/resources/postman/ExpenseService.postman_collection.json
@@ -1,19 +1,35 @@
 {
 	"info": {
-		"_postman_id": "174a2127-e699-42a9-9d20-5eaf6d039392",
+		"_postman_id": "fa3a8a25-a4e6-4916-9745-ea5f47be7954",
 		"name": "ExpenseService",
-		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
-		"_exporter_id": "30821906"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "43003168"
 	},
 	"item": [
 		{
-			"name": "HelloWorld",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": "http://localhost:8000/expenses/v1/helloworld"
-			},
-			"response": []
+			"name": "Receipt",
+			"item": [
+				{
+					"name": "Download File",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/employees/v1/receipts/{{fileId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"employees",
+								"v1",
+								"receipts",
+								"{{fileId}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		},
 		{
 			"name": "CreateExpense",
@@ -80,7 +96,16 @@
 						}
 					]
 				},
-				"url": "http://localhost:8000/expenses/v1"
+				"url": {
+					"raw": "{{port}}/expenses/v1",
+					"host": [
+						"{{port}}"
+					],
+					"path": [
+						"expenses",
+						"v1"
+					]
+				}
 			},
 			"response": []
 		},
@@ -89,7 +114,17 @@
 			"request": {
 				"method": "DELETE",
 				"header": [],
-				"url": "http://localhost:8000/expenses/v1/65d8897f31ddc0266415323a"
+				"url": {
+					"raw": "{{port}}/expenses/v1/{{expenseId}}",
+					"host": [
+						"{{port}}"
+					],
+					"path": [
+						"expenses",
+						"v1",
+						"{{expenseId}}"
+					]
+				}
 			},
 			"response": []
 		},
@@ -99,12 +134,10 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:8000/expenses/v1?startDate=23-02-2024&endDate=28-02-2024&modeOfPayment=UPI&expenseType=Food&expenseCategory=Admin",
-					"protocol": "http",
+					"raw": "{{port}}/expenses/v1?startDate={{startDate}}&endDate={{endDate}}&modeOfPayment={{modeOfPayment}}&expenseType={{expenseType}}&expenseCategory={{categogy}}",
 					"host": [
-						"localhost"
+						"{{port}}"
 					],
-					"port": "8000",
 					"path": [
 						"expenses",
 						"v1"
@@ -112,23 +145,23 @@
 					"query": [
 						{
 							"key": "startDate",
-							"value": "23-02-2024"
+							"value": "{{startDate}}"
 						},
 						{
 							"key": "endDate",
-							"value": "28-02-2024"
+							"value": "{{endDate}}"
 						},
 						{
 							"key": "modeOfPayment",
-							"value": "UPI"
+							"value": "{{modeOfPayment}}"
 						},
 						{
 							"key": "expenseType",
-							"value": "Food"
+							"value": "{{expenseType}}"
 						},
 						{
 							"key": "expenseCategory",
-							"value": "Admin"
+							"value": "{{categogy}}"
 						}
 					]
 				}
@@ -200,7 +233,17 @@
 						}
 					]
 				},
-				"url": "http://localhost:8000/expenses/v1/65d8897f31ddc0266415323a"
+				"url": {
+					"raw": "{{port}}/expenses/v1/{{expenseId}}",
+					"host": [
+						"{{port}}"
+					],
+					"path": [
+						"expenses",
+						"v1",
+						"{{expenseId}}"
+					]
+				}
 			},
 			"response": []
 		},
@@ -209,7 +252,19 @@
 			"request": {
 				"method": "GET",
 				"header": [],
-				"url": "http://localhost:8000/expenses/v1/expenses/673df2617779da548409a0d8/status"
+				"url": {
+					"raw": "{{port}}/expenses/v1/expenses/{{expenseId}}/status",
+					"host": [
+						"{{port}}"
+					],
+					"path": [
+						"expenses",
+						"v1",
+						"expenses",
+						"{{expenseId}}",
+						"status"
+					]
+				}
 			},
 			"response": []
 		},
@@ -218,7 +273,37 @@
 			"request": {
 				"method": "PUT",
 				"header": [],
-				"url": "http://localhost:8000/expenses/v1/673df2617779da548409a0d8/settle"
+				"url": {
+					"raw": "{{port}}/expenses/v1/{{expenseId}}/settle",
+					"host": [
+						"{{port}}"
+					],
+					"path": [
+						"expenses",
+						"v1",
+						"{{expenseId}}",
+						"settle"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Expense Default Values",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{port}}/expenses/v1/expense-values",
+					"host": [
+						"{{port}}"
+					],
+					"path": [
+						"expenses",
+						"v1",
+						"expense-values"
+					]
+				}
 			},
 			"response": []
 		}

--- a/services/beeja-file-management/src/main/resources/postman/FileService.postman_collection.json
+++ b/services/beeja-file-management/src/main/resources/postman/FileService.postman_collection.json
@@ -1,19 +1,11 @@
 {
 	"info": {
-		"_postman_id": "20c211a5-f2c4-4d4c-bf9f-0bf12ff79ccc",
+		"_postman_id": "34f56194-052b-4500-b68f-a34520571df1",
 		"name": "FileService",
-		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
-		"_exporter_id": "30821906"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "43003168"
 	},
 	"item": [
-		{
-			"name": "HelloWorld",
-			"request": {
-				"method": "GET",
-				"header": []
-			},
-			"response": []
-		},
 		{
 			"name": "UploadFile",
 			"request": {
@@ -54,7 +46,17 @@
 						}
 					]
 				},
-				"url": "http://localhost:8000/files/v1/files"
+				"url": {
+					"raw": "{{port}}/files/v1/files",
+					"host": [
+						"{{port}}"
+					],
+					"path": [
+						"files",
+						"v1",
+						"files"
+					]
+				}
 			},
 			"response": []
 		},
@@ -63,7 +65,18 @@
 			"request": {
 				"method": "GET",
 				"header": [],
-				"url": "http://localhost:8000/files/v1/files/TAC0063"
+				"url": {
+					"raw": "{{port}}/files/v1/files/{{employeeId}}",
+					"host": [
+						"{{port}}"
+					],
+					"path": [
+						"files",
+						"v1",
+						"files",
+						"{{employeeId}}"
+					]
+				}
 			},
 			"response": []
 		},
@@ -72,7 +85,19 @@
 			"request": {
 				"method": "GET",
 				"header": [],
-				"url": "http://localhost:8000/files/v1/files/download/65d574ca305b365944350464"
+				"url": {
+					"raw": "{{port}}/files/v1/files/download/{{fileId}}",
+					"host": [
+						"{{port}}"
+					],
+					"path": [
+						"files",
+						"v1",
+						"files",
+						"download",
+						"{{fileId}}"
+					]
+				}
 			},
 			"response": []
 		},
@@ -81,7 +106,18 @@
 			"request": {
 				"method": "DELETE",
 				"header": [],
-				"url": "http://localhost:8000/files/v1/files/65d574ca305b365944350464"
+				"url": {
+					"raw": "{{port}}/files/v1/files/{{fileId}}",
+					"host": [
+						"{{port}}"
+					],
+					"path": [
+						"files",
+						"v1",
+						"files",
+						"{{fileId}}"
+					]
+				}
 			},
 			"response": []
 		},
@@ -125,7 +161,68 @@
 						}
 					]
 				},
-				"url": "http://localhost:8000/files/v1/files/65d574ca305b365944350464"
+				"url": {
+					"raw": "{{port}}/files/v1/files/{{fileId}}",
+					"host": [
+						"{{port}}"
+					],
+					"path": [
+						"files",
+						"v1",
+						"files",
+						"{{fileId}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get All Files By EntityId",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{port}}/files/v1/files/{{fileId}}?page=1&size=5",
+					"host": [
+						"{{port}}"
+					],
+					"path": [
+						"files",
+						"v1",
+						"files",
+						"{{fileId}}"
+					],
+					"query": [
+						{
+							"key": "page",
+							"value": "1"
+						},
+						{
+							"key": "size",
+							"value": "5"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Upload Or UpdateFile",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"url": {
+					"raw": "{{port}}/files/v1/files/dynamic",
+					"host": [
+						"{{port}}"
+					],
+					"path": [
+						"files",
+						"v1",
+						"files",
+						"dynamic"
+					]
+				}
 			},
 			"response": []
 		},
@@ -155,12 +252,10 @@
 					]
 				},
 				"url": {
-					"raw": "http://localhost:8000/finance/v1/payslips",
-					"protocol": "http",
+					"raw": "{{port}}/finance/v1/payslips",
 					"host": [
-						"localhost"
+						"{{port}}"
 					],
-					"port": "8000",
 					"path": [
 						"finance",
 						"v1",

--- a/services/beeja-finance/src/main/resources/postman/FinanceService.postman_collection.json
+++ b/services/beeja-finance/src/main/resources/postman/FinanceService.postman_collection.json
@@ -1,206 +1,402 @@
 {
 	"info": {
-		"_postman_id": "d30b2093-88b4-4f78-870a-7d6f16421040",
+		"_postman_id": "723e849f-e7b4-4930-9308-be5b73fd855b",
 		"name": "FinanceService",
-		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
-		"_exporter_id": "30821906"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "43003168"
 	},
 	"item": [
 		{
-			"name": "HelloWorld",
-			"request": {
-				"method": "GET",
-				"header": []
-			},
-			"response": []
-		},
-		{
-			"name": "BulkPaySlips",
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "formdata",
-					"formdata": [
-						{
-							"key": "zipFile",
-							"type": "file",
-							"src": "/C:/Users/User/Downloads/app (1).zip"
+			"name": "Bulk Pay Slips",
+			"item": [
+				{
+					"name": "BulkPaySlips",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "zipFile",
+									"type": "file",
+									"src": "/C:/Users/User/Downloads/app (1).zip"
+								},
+								{
+									"key": "month",
+									"value": "12",
+									"type": "text"
+								},
+								{
+									"key": "year",
+									"value": "2023",
+									"type": "text"
+								}
+							]
 						},
-						{
-							"key": "month",
-							"value": "12",
-							"type": "text"
-						},
-						{
-							"key": "year",
-							"value": "2023",
-							"type": "text"
+						"url": {
+							"raw": "{{port}}/finance/v1/payslips",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"finance",
+								"v1",
+								"payslips"
+							],
+							"query": [
+								{
+									"key": "",
+									"value": null,
+									"disabled": true
+								}
+							]
 						}
-					]
-				},
-				"url": {
-					"raw": "http://localhost:8000/finance/v1/payslips",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8000",
-					"path": [
-						"finance",
-						"v1",
-						"payslips"
-					],
-					"query": [
-						{
-							"key": "",
-							"value": null,
-							"disabled": true
-						}
-					]
+					},
+					"response": []
 				}
-			},
-			"response": []
+			]
 		},
 		{
-			"name": "GetAllLoans",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": "http://localhost:8000/finance/v1/loans"
-			},
-			"response": []
-		},
-		{
-			"name": "GetLoanByEmployeeId",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": "http://localhost:8000/finance/v1/loans/TAC0063"
-			},
-			"response": []
-		},
-		{
-			"name": "UpdateLoanStatus",
-			"request": {
-				"method": "PUT",
-				"header": [],
-				"url": {
-					"raw": "http://localhost:8000/finance/v1/loans/654b1445f694093d4da8df36?status=Approved&message=abcd",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8000",
-					"path": [
-						"finance",
-						"v1",
-						"loans",
-						"654b1445f694093d4da8df36"
-					],
-					"query": [
-						{
-							"key": "status",
-							"value": "Approved"
+			"name": "Health Insurence",
+			"item": [
+				{
+					"name": "Submit Health Insurance",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"id\": \"POLICY001\",\r\n    \"employeeId\": \"EMP12345\",\r\n    \"organizationId\": \"ORG67890\",\r\n    \"grossPremium\": \"5000\",\r\n    \"instalmentType\": \"MONTHLY\",\r\n    \"instalmentAmount\": 200.0,\r\n    \"instalmentFrequency\": 12\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
 						},
-						{
-							"key": "message",
-							"value": "abcd"
+						"url": {
+							"raw": "{{port}}/finance/v1/health-insurances",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"finance",
+								"v1",
+								"health-insurances"
+							]
 						}
-					]
+					},
+					"response": []
+				},
+				{
+					"name": "Update Health Insurance",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"id\": \"POLICY001\",\r\n    \"employeeId\": \"EMP12345\",\r\n    \"organizationId\": \"ORG67890\",\r\n    \"grossPremium\": \"5000\",\r\n    \"instalmentType\": \"MONTHLY\",\r\n    \"instalmentAmount\": 200.0,\r\n    \"instalmentFrequency\": 12\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/finance/v1/health-insurances/employee/{{employeeId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"finance",
+								"v1",
+								"health-insurances",
+								"employee",
+								"{{employeeId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete Health Insurance",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/finance/v1/health-insurances/employee/{{employeeId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"finance",
+								"v1",
+								"health-insurances",
+								"employee",
+								"{{employeeId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Health Insurance By EmployeeId ",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/finance/v1/health-insurances/{{employeeId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"finance",
+								"v1",
+								"health-insurances",
+								"{{employeeId}}"
+							]
+						}
+					},
+					"response": []
 				}
-			},
-			"response": []
+			]
 		},
 		{
-			"name": "CreateLoan",
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"loanType\":\"PERSONAL_LOAN\",\r\n    \"amount\":1000,\r\n    \"monthlyEMI\":100,\r\n    \"purpose\":\"Home Renovation\",\r\n    \"emiTenure\":12,\r\n    \"emiStartDate\":\"2024-02-01\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+			"name": "Inventory",
+			"item": [
+				{
+					"name": "Add Device",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"device\": \"LAPTOP\",\r\n    \"provider\": \"Tech\",\r\n    \"model\": \"intel core\",\r\n    \"type\": \"OLD\",\r\n    \"os\": \"windows\",\r\n    \"specifications\": \"8GB RAM, 128GB Storage\",\r\n    \"RAM\": \"8GB\",\r\n    \"availability\": \"YES\",\r\n    \"productId\": \"PROD09876\",\r\n    \"price\": 100000.99,\r\n    \"dateOfPurchase\": \"2024-12-03T10:00:00Z\",\r\n  \"comments\": \"This is a new device.\",\r\n  \"accessoryType\": \"Charger\",\r\n  \"createdAt\": \"2024-12-03T10:00:00Z\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/finance/v1/inventory",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"finance",
+								"v1",
+								"inventory"
+							]
 						}
-					}
+					},
+					"response": []
 				},
-				"url": "http://localhost:8000/finance/v1/loans"
-			},
-			"response": []
-		},
-		{
-			"name": "Add Device",
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"device\": \"LAPTOP\",\r\n    \"provider\": \"Tech\",\r\n    \"model\": \"intel core\",\r\n    \"type\": \"OLD\",\r\n    \"os\": \"windows\",\r\n    \"specifications\": \"8GB RAM, 128GB Storage\",\r\n    \"RAM\": \"8GB\",\r\n    \"availability\": \"YES\",\r\n    \"productId\": \"PROD09876\",\r\n    \"price\": 100000.99,\r\n    \"dateOfPurchase\": \"2024-12-03T10:00:00Z\",\r\n  \"comments\": \"This is a new device.\",\r\n  \"accessoryType\": \"Charger\",\r\n  \"createdAt\": \"2024-12-03T10:00:00Z\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+				{
+					"name": "Filter Inventory",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/finance/v1/inventory?pageNumber=1&pageSize=10&device=LAPTOP&provider=DELL&availability=AVAILABLE&os=Windows&RAM=8GB&searchTerm=touchscreen",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"finance",
+								"v1",
+								"inventory"
+							],
+							"query": [
+								{
+									"key": "pageNumber",
+									"value": "1"
+								},
+								{
+									"key": "pageSize",
+									"value": "10"
+								},
+								{
+									"key": "device",
+									"value": "LAPTOP"
+								},
+								{
+									"key": "provider",
+									"value": "DELL"
+								},
+								{
+									"key": "availability",
+									"value": "AVAILABLE"
+								},
+								{
+									"key": "os",
+									"value": "Windows"
+								},
+								{
+									"key": "RAM",
+									"value": "8GB"
+								},
+								{
+									"key": "searchTerm",
+									"value": "touchscreen"
+								}
+							]
 						}
-					}
+					},
+					"response": []
 				},
-				"url": "http://localhost:8000/finance/v1/inventory"
-			},
-			"response": []
-		},
-		{
-			"name": "Filter Inventory",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": "http://localhost:8000/finance/v1/inventory"
-			},
-			"response": []
-		},
-		{
-			"name": "Delete Device",
-			"request": {
-				"method": "DELETE",
-				"header": [],
-				"url": "http://localhost:8000/finance/v1/inventory/674eb0dd1ff0a0057a08b077"
-			},
-			"response": []
-		},
-		{
-			"name": "Update Device",
-			"request": {
-				"method": "PUT",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"device\": \"LAPTOP\",\r\n    \"provider\": \"Tech\",\r\n    \"model\": \"intel core\",\r\n    \"type\": \"OLD\",\r\n    \"os\": \"windows\",\r\n    \"specifications\": \"16GB RAM, 128GB Storage\",\r\n    \"RAM\": \"16GB\",\r\n    \"availability\": \"YES\",\r\n    \"productId\": \"PROD098\",\r\n    \"price\": 100000.99,\r\n    \"dateOfPurchase\": \"2024-12-03T10:00:00Z\",\r\n  \"comments\": \"This is a new device.\",\r\n  \"accessoryType\": \"Charger\",\r\n  \"createdAt\": \"2024-12-03T10:00:00Z\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+				{
+					"name": "Delete Device",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/finance/v1/inventory/{{deviceId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"finance",
+								"v1",
+								"inventory",
+								"{{deviceId}}"
+							]
 						}
-					}
+					},
+					"response": []
 				},
-				"url": "http://localhost:8000/finance/v1/inventory/67508eb4bddf8e26628747f1"
-			},
-			"response": []
+				{
+					"name": "Update Device",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"device\": \"LAPTOP\",\r\n    \"provider\": \"Tech\",\r\n    \"model\": \"intel core\",\r\n    \"type\": \"OLD\",\r\n    \"os\": \"windows\",\r\n    \"specifications\": \"16GB RAM, 128GB Storage\",\r\n    \"RAM\": \"16GB\",\r\n    \"availability\": \"YES\",\r\n    \"productId\": \"PROD098\",\r\n    \"price\": 100000.99,\r\n    \"dateOfPurchase\": \"2024-12-03T10:00:00Z\",\r\n  \"comments\": \"This is a new device.\",\r\n  \"accessoryType\": \"Charger\",\r\n  \"createdAt\": \"2024-12-03T10:00:00Z\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/finance/v1/inventory/{{deviceId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"finance",
+								"v1",
+								"inventory",
+								"{{deviceId}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		},
 		{
-			"name": "Submit Health Insurance",
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"id\": \"POLICY001\",\r\n    \"employeeId\": \"EMP12345\",\r\n    \"organizationId\": \"ORG67890\",\r\n    \"grossPremium\": \"5000\",\r\n    \"instalmentType\": \"MONTHLY\",\r\n    \"instalmentAmount\": 200.0,\r\n    \"instalmentFrequency\": 12\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
+			"name": "Loan",
+			"item": [
+				{
+					"name": "GetAllLoans",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/finance/v1/loans",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"finance",
+								"v1",
+								"loans"
+							]
 						}
-					}
+					},
+					"response": []
 				},
-				"url": "http://localhost:8000/finance/v1/health-insurances"
-			},
-			"response": []
+				{
+					"name": "GetLoanByEmployeeId",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/finance/v1/loans/{{employeeId}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"finance",
+								"v1",
+								"loans",
+								"{{employeeId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "UpdateLoanStatus",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/finance/v1/loans/{{loanId}}?status=Approved&message=abcd",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"finance",
+								"v1",
+								"loans",
+								"{{loanId}}"
+							],
+							"query": [
+								{
+									"key": "status",
+									"value": "Approved"
+								},
+								{
+									"key": "message",
+									"value": "abcd"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "CreateLoan",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"loanType\":\"PERSONAL_LOAN\",\r\n    \"amount\":1000,\r\n    \"monthlyEMI\":100,\r\n    \"purpose\":\"Home Renovation\",\r\n    \"emiTenure\":12,\r\n    \"emiStartDate\":\"2024-02-01\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/finance/v1/loans",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"finance",
+								"v1",
+								"loans"
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		}
 	]
 }

--- a/services/beeja-recruitment/src/main/resources/postman/recruitmentService.postman_collection.json
+++ b/services/beeja-recruitment/src/main/resources/postman/recruitmentService.postman_collection.json
@@ -1,0 +1,349 @@
+{
+	"info": {
+		"_postman_id": "8679775e-4a4a-48f9-a2ef-b15e56e1d0b8",
+		"name": "recruitmentService",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "43003168"
+	},
+	"item": [
+		{
+			"name": "Applicant",
+			"item": [
+				{
+					"name": "Get Applicants By Filter",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/recruitments/v1/applicants/combinedApplicants?firstName=Bruce",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"recruitments",
+								"v1",
+								"applicants",
+								"combinedApplicants"
+							],
+							"query": [
+								{
+									"key": "firstName",
+									"value": "Bruce"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get All Applicants",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"firstName\":\"Deo\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/recruitments/v1/applicants",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"recruitments",
+								"v1",
+								"applicants"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update Applicant By Patch Method",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"firstName\":\"Reo\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/recruitments/v1/applicants/{{applicantID}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"recruitments",
+								"v1",
+								"applicants",
+								"{{applicantID}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Applicant By Id",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/recruitments/v1/applicants/{{applicantID}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"recruitments",
+								"v1",
+								"applicants",
+								"{{applicantID}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Download File",
+					"request": {
+						"method": "GET",
+						"header": []
+					},
+					"response": []
+				},
+				{
+					"name": "Submit FeedBack",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"applicantComments\":\"This is the new feed back\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/recruitments/v1/applicants/feedback/{{applicantID}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"recruitments",
+								"v1",
+								"applicants",
+								"feedback",
+								"{{applicantID}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Assign Interviewer",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"assignedInterviewers\":\"Kiran\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/recruitments/v1/applicants/{{applicantID}}/assign-interviewer",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"recruitments",
+								"v1",
+								"applicants",
+								"{{applicantID}}",
+								"assign-interviewer"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add Comment To Applicant",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"applicantId\":\"67ea4464c9ab837f813c9f43\",\r\n    \"comment\":\"Best performer\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{port}}/recruitments/v1/applicants/comments",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"recruitments",
+								"v1",
+								"applicants",
+								"comments"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Change Status Of Applicant",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/recruitments/v1/applicants/67ea4464c9ab837f813c9f43/status/{{status}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"recruitments",
+								"v1",
+								"applicants",
+								"67ea4464c9ab837f813c9f43",
+								"status",
+								"{{status}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete Interviewer By InterviewID",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{port}}/recruitments/v1/applicants/{{applicantID}}/interview/{{interviewID}}",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"recruitments",
+								"v1",
+								"applicants",
+								"{{applicantID}}",
+								"interview",
+								"{{interviewID}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Referrals",
+			"item": [
+				{
+					"name": "Get All My Referrals",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "resumeId",
+									"value": "",
+									"type": "text",
+									"disabled": true
+								}
+							]
+						},
+						"url": {
+							"raw": "{{port}}/recruitments/v1/referrals",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"recruitments",
+								"v1",
+								"referrals"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add new Referal",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "resumeId",
+									"type": "file",
+									"src": "/C:/Users/prane/OneDrive/Documents/PraneethUniversityAdmissions/Desktop/1740205983257.jpg"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{port}}/recruitments/v1/referrals",
+							"host": [
+								"{{port}}"
+							],
+							"path": [
+								"recruitments",
+								"v1",
+								"referrals"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Download Resume",
+					"request": {
+						"method": "GET",
+						"header": []
+					},
+					"response": []
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
I have added and updated missing Postman collections for backend services including accounts, employee, file-management, expenses, and finance. I also created a new collection for the recruitment service. All collections are organized based on controller structure and include relevant endpoints with example requests, headers, and authentication details where needed. These collections are committed to their respective service folders and are ready for review.