### PR TITLE
feat:Configured Swagger API for Recruitment Service

### DIFF
--- a/services/beeja-recruitment/src/main/resources/static/openApi.yaml
+++ b/services/beeja-recruitment/src/main/resources/static/openApi.yaml
@@ -34,24 +34,53 @@ paths:
               $ref: '#/components/schemas/ApplicantRequest'
       responses:
         '200':
-          description: Successfully created
+          description: Applicant created successfully
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Applicant'
-
+          '400':
+            description: Invalid applicant input
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/BadRequest'
+          '403':
+            description: Forbidden to create applicant
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Forbidden'
+          '500':
+            description: Internal server error
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/InternalServerError'
     get:
       summary: Get all applicants in the organization
       tags: [Applicants]
       responses:
-        '200':
-          description: List of applicants
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Applicant'
+          '200':
+            description: List of applicants fetched
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Applicant'
+          '403':
+            description: Access denied to view applicants
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Forbidden'
+          '500':
+            description: Server error while fetching applicants
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/InternalServerError'
 
   /v1/applicants/combinedApplicants:
     get:
@@ -106,12 +135,25 @@ paths:
             type: string
             enum: [asc, desc]
       responses:
-        '200':
-          description: Paginated applicant response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedApplicantResponse'
+          '200':
+            description: Paginated applicant list fetched
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/PaginatedApplicantsResponse'
+          '403':
+            description: Forbidden to view applicants
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Forbidden'
+          '500':
+            description: Server error while fetching paginated list
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/InternalServerError'
+
 
   /v1/applicants/{applicantID}:
     get:
@@ -124,12 +166,25 @@ paths:
           schema:
             type: string
       responses:
-        '200':
-          description: Applicant object
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Applicant'
+          '200':
+            description: Applicant found
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Applicant'
+          '404':
+            description: Applicant not found
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/NotFound'
+          '500':
+            description: Error while fetching applicant
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/InternalServerError'
+
 
     patch:
       summary: Update applicant partially
@@ -147,11 +202,30 @@ paths:
             type: string
       responses:
         '200':
-          description: Updated applicant
+          description: Applicant updated successfully
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Applicant'
+        '400':
+          description: Invalid input for update
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+        '404':
+          description: Applicant not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+        '500':
+          description: Server error while updating
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+
 
   /v1/applicants/{applicantID}/assign-interviewer:
     patch:
@@ -170,11 +244,19 @@ paths:
             type: string
       responses:
         '200':
-          description: Assigned successfully
+          description: Interviewer assigned
+        '400':
+          description: Invalid interviewer details
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Applicant'
+                $ref: '#/components/schemas/BadRequest'
+        '404':
+          description: Applicant not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
 
   /v1/applicants/feedback/{applicantID}:
     patch:
@@ -194,10 +276,19 @@ paths:
       responses:
         '200':
           description: Feedback submitted
+        '400':
+          description: Feedback input invalid
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Applicant'
+                $ref: '#/components/schemas/BadRequest'
+        '404':
+          description: Applicant not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+
 
   /v1/applicants/resume/{fileId}:
     get:
@@ -211,12 +302,25 @@ paths:
             type: string
       responses:
         '200':
-          description: Resume file
+          description: Resume file downloaded
           content:
             application/octet-stream:
               schema:
                 type: string
                 format: binary
+        '404':
+          description: Resume not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+        '500':
+          description: Download error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+
 
   /v1/applicants/{applicantID}/status/{status}:
     put:
@@ -235,7 +339,20 @@ paths:
             $ref: '#/components/schemas/ApplicantStatus'
       responses:
         '200':
-          description: Status changed
+          description: Status updated
+        '400':
+          description: Invalid status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+        '404':
+          description: Applicant not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+
 
   /v1/applicants/comments:
     post:
@@ -249,6 +366,13 @@ paths:
       responses:
         '200':
           description: Comment added
+        '400':
+          description: Invalid comment data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+
 
   /v1/applicants/{applicantID}/interview/{interviewID}:
     delete:
@@ -267,7 +391,14 @@ paths:
             type: string
       responses:
         '200':
-          description: Interview deleted
+          description: Interviewer removed
+        '404':
+          description: Interview record not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+
 
   /v1/referrals:
     post:
@@ -280,24 +411,56 @@ paths:
               $ref: '#/components/schemas/ApplicantRequest'
       responses:
         '200':
-          description: Referral created
+          description: Referral created successfully
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Applicant'
+        '400':
+          description: Invalid referral request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+        '401':
+          description: Unauthorized to create referral
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
+        '500':
+          description: Internal server error while creating referral
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+
 
     get:
       summary: Get all my referrals
       tags: [Referrals]
       responses:
         '200':
-          description: List of referrals
+          description: Fetched all referrals successfully
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Applicant'
+        '401':
+          description: Unauthorized to view referrals
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
+        '500':
+          description: Internal server error while fetching referrals
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+
 
   /v1/referrals/{resumeId}:
     get:
@@ -311,12 +474,31 @@ paths:
             type: string
       responses:
         '200':
-          description: Resume file
+          description: Resume downloaded successfully
           content:
             application/octet-stream:
               schema:
                 type: string
                 format: binary
+        '401':
+          description: Unauthorized access to resume
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Unauthorized'
+        '404':
+          description: Resume not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+        '500':
+          description: Error occurred while downloading resume
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+
 
 components:
   schemas:
@@ -335,8 +517,10 @@ components:
           type: string
         status:
           $ref: '#/components/schemas/ApplicantStatus'
+
     ApplicantRequest:
       type: object
+      required: [firstName, lastName, email, phoneNumber, positionAppliedFor]
       properties:
         firstName:
           type: string
@@ -344,29 +528,43 @@ components:
           type: string
         email:
           type: string
-        phone:
+        phoneNumber:
           type: string
+        positionAppliedFor:
+          type: string
+        resume:
+          type: string
+          format: binary
+        experience:
+          type: string
+
     AssignedInterviewer:
       type: object
+      required: [name, email]
       properties:
         name:
           type: string
         email:
           type: string
+
     ApplicantFeedbackRequest:
       type: object
+      required: [feedback, rating]
       properties:
         feedback:
           type: string
         rating:
           type: number
+
     AddCommentRequest:
       type: object
+      required: [applicantId, comment]
       properties:
         applicantId:
           type: string
         comment:
           type: string
+
     PaginatedApplicantResponse:
       type: object
       properties:
@@ -376,10 +574,33 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Applicant'
+
     ApplicantStatus:
       type: string
-      enum: [APPLIED,
-             SHORTLISTED,
-             INTERVIEW_SCHEDULED,
-             HIRED,
-             REJECTED]
+      enum: [APPLIED, SHORTLISTED, INTERVIEW_SCHEDULED, HIRED, REJECTED]
+
+    BadRequest:
+      type: object
+      properties:
+        message:
+          type: string
+    Unauthorized:
+        type: object
+        properties:
+          message:
+            type: string
+    NotFound:
+        type: object
+        properties:
+          message:
+            type: string
+    Forbidden:
+      type: object
+      properties:
+        message:
+          type: string
+    InternalServerError:
+      type: object
+      properties:
+        message:
+          type: string

--- a/services/beeja-recruitment/src/main/resources/static/openApi.yaml
+++ b/services/beeja-recruitment/src/main/resources/static/openApi.yaml
@@ -1,0 +1,385 @@
+openapi: 3.0.1
+info:
+  title: Beeja Recruitment Service
+  version: v1
+  description: |-
+    `Product of tech.at.core`
+       API documentation for the Beeja Recruitment Open API application.
+       This service provides endpoints for managing applicants and referrals. 
+       It includes functionalities such as creating, updating,and retrieving applicant information, 
+       assigning interviewers, submitting feedback, and handling referrals.
+    
+        ## Authentication & Authorization
+        Beeja uses an authentication system that is secured by username and password.
+        [Please login to Beeja](http://localhost:8000/login) to access all APIs in Swagger.
+
+externalDocs:
+  description: Explore Beeja Recruitment API
+  url: https://beeja.io/
+
+servers:
+  - url: http://localhost:8000/recruitments
+    description: Recruitment APIs
+
+paths:
+  /v1/applicants:
+    post:
+      summary: Create a new applicant
+      tags: [Applicants]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplicantRequest'
+      responses:
+        '200':
+          description: Successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Applicant'
+
+    get:
+      summary: Get all applicants in the organization
+      tags: [Applicants]
+      responses:
+        '200':
+          description: List of applicants
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Applicant'
+
+  /v1/applicants/combinedApplicants:
+    get:
+      summary: Get paginated applicants with filters
+      tags: [Applicants]
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+        - in: query
+          name: limit
+          schema:
+            type: integer
+        - in: query
+          name: applicantId
+          schema:
+            type: string
+        - in: query
+          name: firstName
+          schema:
+            type: string
+        - in: query
+          name: positionAppliedFor
+          schema:
+            type: string
+        - in: query
+          name: status
+          schema:
+            $ref: '#/components/schemas/ApplicantStatus'
+        - in: query
+          name: experience
+          schema:
+            type: string
+        - in: query
+          name: fromDate
+          schema:
+            type: string
+            format: date
+        - in: query
+          name: toDate
+          schema:
+            type: string
+            format: date
+        - in: query
+          name: sortBy
+          schema:
+            type: string
+        - in: query
+          name: sortDirection
+          schema:
+            type: string
+            enum: [asc, desc]
+      responses:
+        '200':
+          description: Paginated applicant response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedApplicantResponse'
+
+  /v1/applicants/{applicantID}:
+    get:
+      summary: Get applicant by ID
+      tags: [Applicants]
+      parameters:
+        - in: path
+          name: applicantID
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Applicant object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Applicant'
+
+    patch:
+      summary: Update applicant partially
+      tags: [Applicants]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      parameters:
+        - in: path
+          name: applicantID
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Updated applicant
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Applicant'
+
+  /v1/applicants/{applicantID}/assign-interviewer:
+    patch:
+      summary: Assign interviewer to applicant
+      tags: [Applicants]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssignedInterviewer'
+      parameters:
+        - in: path
+          name: applicantID
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Assigned successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Applicant'
+
+  /v1/applicants/feedback/{applicantID}:
+    patch:
+      summary: Submit feedback for applicant
+      tags: [Applicants]
+      parameters:
+        - in: path
+          name: applicantID
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplicantFeedbackRequest'
+      responses:
+        '200':
+          description: Feedback submitted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Applicant'
+
+  /v1/applicants/resume/{fileId}:
+    get:
+      summary: Download applicant resume
+      tags: [Applicants]
+      parameters:
+        - in: path
+          name: fileId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Resume file
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+
+  /v1/applicants/{applicantID}/status/{status}:
+    put:
+      summary: Change status of applicant
+      tags: [Applicants]
+      parameters:
+        - in: path
+          name: applicantID
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: status
+          required: true
+          schema:
+            $ref: '#/components/schemas/ApplicantStatus'
+      responses:
+        '200':
+          description: Status changed
+
+  /v1/applicants/comments:
+    post:
+      summary: Add comment to applicant
+      tags: [Applicants]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddCommentRequest'
+      responses:
+        '200':
+          description: Comment added
+
+  /v1/applicants/{applicantID}/interview/{interviewID}:
+    delete:
+      summary: Delete interview from applicant
+      tags: [Applicants]
+      parameters:
+        - in: path
+          name: applicantID
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: interviewID
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Interview deleted
+
+  /v1/referrals:
+    post:
+      summary: Create new referral
+      tags: [Referrals]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplicantRequest'
+      responses:
+        '200':
+          description: Referral created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Applicant'
+
+    get:
+      summary: Get all my referrals
+      tags: [Referrals]
+      responses:
+        '200':
+          description: List of referrals
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Applicant'
+
+  /v1/referrals/{resumeId}:
+    get:
+      summary: Download referral resume
+      tags: [Referrals]
+      parameters:
+        - in: path
+          name: resumeId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Resume file
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+
+components:
+  schemas:
+    Applicant:
+      type: object
+      properties:
+        id:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        phone:
+          type: string
+        status:
+          $ref: '#/components/schemas/ApplicantStatus'
+    ApplicantRequest:
+      type: object
+      properties:
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        phone:
+          type: string
+    AssignedInterviewer:
+      type: object
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+    ApplicantFeedbackRequest:
+      type: object
+      properties:
+        feedback:
+          type: string
+        rating:
+          type: number
+    AddCommentRequest:
+      type: object
+      properties:
+        applicantId:
+          type: string
+        comment:
+          type: string
+    PaginatedApplicantResponse:
+      type: object
+      properties:
+        totalElements:
+          type: integer
+        applicants:
+          type: array
+          items:
+            $ref: '#/components/schemas/Applicant'
+    ApplicantStatus:
+      type: string
+      enum: [APPLIED,
+             SHORTLISTED,
+             INTERVIEW_SCHEDULED,
+             HIRED,
+             REJECTED]

--- a/services/beeja-recruitment/src/main/resources/static/openApi.yaml
+++ b/services/beeja-recruitment/src/main/resources/static/openApi.yaml
@@ -29,9 +29,35 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ApplicantRequest'
+              type: object
+              required:
+                - firstName
+                - lastName
+                - email
+                - phoneNumber
+                - positionAppliedFor
+                - resume
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                email:
+                  type: string
+                  format: email
+                phoneNumber:
+                  type: string
+                positionAppliedFor:
+                  type: string
+                experience:
+                  type: string
+                  nullable: true
+                  description: it is an optional field
+                resume:
+                  type: string
+                  format: binary
       responses:
         '200':
           description: Applicant created successfully
@@ -140,7 +166,7 @@ paths:
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/PaginatedApplicantsResponse'
+                  $ref: '#/components/schemas/PaginatedApplicantResponse'
           '403':
             description: Forbidden to view applicants
             content:


### PR DESCRIPTION
- Integrated Springdoc OpenAPI 3.0.1 for API documentation.

- Created detailed openApi.yaml covering all applicant and referral endpoints.

- Added summaries, request/response schemas, and status codes for all APIs.

- Grouped endpoints using tags like Applicants and Referrals.

- Configured Swagger UI at :- http://localhost:8000/recruitments/swagger-ui/index.html

- Defined all necessary models under components/schemas.