### PR TITLE
Fixed UI issues in KYC tab navigation and in Bank Account number

### DIFF
--- a/web/src/components/reusableComponents/MyProfileKYCTabContent.component.tsx
+++ b/web/src/components/reusableComponents/MyProfileKYCTabContent.component.tsx
@@ -349,8 +349,14 @@ const KycTabContent = ({
                       <div>
                         <InlineInput
                           type="text"
-                          value={formData[label]}
-                          placeholder={`Enter ${t(label)}`}
+                          value={Number(formData[label]) === 0 ? '' : formData[label] ?? ''}
+                          placeholder={
+                            label === 'Account Number'
+                            ? 'Enter Account Number'
+                            : label === 'IFSC Code'
+                            ? 'Enter IFSC Code'
+                            : `Enter ${t(label)}`
+                        }
                           onChange={(e) => handleChange(label, e.target.value)}
                           onBlur={() => handleBlur(label)}
                           maxLength={

--- a/web/src/components/reusableComponents/MyProfileTabsContainer.component.tsx
+++ b/web/src/components/reusableComponents/MyProfileTabsContainer.component.tsx
@@ -472,6 +472,7 @@ const MyProfileTabsContainerComponent = ({
                 onClick={() => {
                   handleTabChange('kyc');
                   handleIsActiveTab('kyc');
+                  chooseTab('KYC');
                 }}
               >
                 {t('KYC')}


### PR DESCRIPTION
This PR includes :
When an employee or privileged user selects the KYC tab, the page heading is displaying correctly.
After saving a bank account number, re-entering Edit mode it was showing the correct saved value, not "0" or any placeholder.

