### PR TITLE
fix : sort by createDate in expense service

### DIFF
--- a/services/beeja-expense/src/main/java/com/beeja/api/expense/ExpenseManagementApplication.java
+++ b/services/beeja-expense/src/main/java/com/beeja/api/expense/ExpenseManagementApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 
 @SpringBootApplication
 @EnableDiscoveryClient
 @EnableFeignClients
+@EnableMongoAuditing
 public class ExpenseManagementApplication {
 
   public static void main(String[] args) {


### PR DESCRIPTION
This PR Introduces :

- While creating a new expense, the createdAt field was not being assigned manually in the createExpense method.
- Because of this, sorting by createdAt was not working properly when fetching expenses.
- I implemented @EnableMongoAuditing to automatically populate the createdAt field at the time of expense creation.
- After this change, the createdAt field was correctly populated, and sorting by creation date started working as expected.