### PR TITLE
fix: fixed the handle null createdAt in loan preview

### DIFF
--- a/web/src/components/directComponents/LoanPreview.component.tsx
+++ b/web/src/components/directComponents/LoanPreview.component.tsx
@@ -28,6 +28,15 @@ const LoanPreview = (props: LoanPreviewProps) => {
     props.handleClose();
   });
   const { t } = useTranslation();
+
+  const safeFormatDate = (dateString: string | null | undefined) => {
+    if (!dateString) return '-';
+    try {
+      return formatDate(dateString);
+    } catch {
+      return '-';
+    }
+  };
   return (
     <LoanPreviewModal>
       <div>
@@ -65,7 +74,7 @@ const LoanPreview = (props: LoanPreviewProps) => {
           <label>{t('REQUESTED_DATE')} </label>
           <TextInput
             className={'disabledBgWhite'}
-            value={formatDate(props.loan.createdAt.toString())}
+            value={safeFormatDate(props.loan.createdAt?.toString())}
             disabled={true}
           />
         </InputLabelContainer>

--- a/web/src/components/directComponents/LoanPreview.component.tsx
+++ b/web/src/components/directComponents/LoanPreview.component.tsx
@@ -14,7 +14,7 @@ import {
   TextInput,
 } from '../../styles/DocumentTabStyles.style';
 import { LoanPreviewModal } from '../../styles/LoanPreviewStyles.style';
-import { formatDate, monthsDiff } from '../../utils/dateFormatter';
+import {  monthsDiff, safeFormatDate } from '../../utils/dateFormatter';
 import { hasPermission } from '../../utils/permissionCheck';
 
 type LoanPreviewProps = {
@@ -29,14 +29,6 @@ const LoanPreview = (props: LoanPreviewProps) => {
   });
   const { t } = useTranslation();
 
-  const safeFormatDate = (dateString: string | null | undefined) => {
-    if (!dateString) return '-';
-    try {
-      return formatDate(dateString);
-    } catch {
-      return '-';
-    }
-  };
   return (
     <LoanPreviewModal>
       <div>

--- a/web/src/utils/dateFormatter.ts
+++ b/web/src/utils/dateFormatter.ts
@@ -79,3 +79,13 @@ export function formatDateDDMMYYYYHHMM(dateString: string): string {
 
   return `${day}-${month}-${year} ${hours}:${minutes}`;
 }
+export const safeFormatDate = (dateString: string | null | undefined): string => {
+  if (!dateString) return '-';
+  
+  try {
+    return formatDate(dateString);
+  } catch (error) {
+    console.error('Failed to format date:', error);
+    return '-';
+  }
+};


### PR DESCRIPTION
This PR introduces 
Fixed the display issue of a loan preview when the loan list have 'created at' value is null .