### PR TITLE
feat:BEEJA Integration with Microsoft Teams for Birthday Notifications

### DIFF
--- a/services/beeja-accounts/src/main/java/com/beeja/api/accounts/controllers/InternalOrganizationController.java
+++ b/services/beeja-accounts/src/main/java/com/beeja/api/accounts/controllers/InternalOrganizationController.java
@@ -1,0 +1,28 @@
+package com.beeja.api.accounts.controllers;
+
+import com.beeja.api.accounts.service.OrganizationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/internal/api/organizations")
+@RequiredArgsConstructor
+public class InternalOrganizationController {
+
+    private final OrganizationService organizationService;
+
+    @GetMapping("/birthday-notifications/enabled")
+    public List<String> getEnabledOrganizations() throws Exception {
+        return organizationService.getOrganizationsWithBirthdayNotificationsEnabled();
+    }
+
+    @GetMapping("/{orgId}/birthday-webhook")
+    public String getBirthdayWebhookUrl(@PathVariable String orgId) throws Exception {
+        return organizationService.getBirthdayWebhookUrl(orgId);
+    }
+}

--- a/services/beeja-accounts/src/main/java/com/beeja/api/accounts/controllers/OrganizationController.java
+++ b/services/beeja-accounts/src/main/java/com/beeja/api/accounts/controllers/OrganizationController.java
@@ -98,4 +98,14 @@ public class OrganizationController {
     organizationService.generateOrganizationDefaults();
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
+
+  @PutMapping("/{id}/birthday-preferences")
+  public ResponseEntity<Void> updateBirthdayPreference(
+          @PathVariable String id,
+          @RequestParam boolean enabled,
+          @RequestParam(required = false) String webhookUrl) throws Exception {
+
+    organizationService.updateBirthdayPreference(id, enabled, webhookUrl);
+    return ResponseEntity.ok().build();
+  }
 }

--- a/services/beeja-accounts/src/main/java/com/beeja/api/accounts/model/Organization/Organization.java
+++ b/services/beeja-accounts/src/main/java/com/beeja/api/accounts/model/Organization/Organization.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.URL;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 @Data
 @AllArgsConstructor
@@ -27,6 +28,11 @@ public class Organization {
 
   private String subscriptionId;
   private String emailDomain;
+  @Field("is_birthday_notification_enabled")
+  private boolean isBirthDayNotificationEnabled = false;
+
+  @Field("birthday_webhook_url")
+  private String birthdayWebhookUrl;
 
   @NotBlank(message = Constants.VALIDATION_ORGANIZATION_OWNER_CONTACT_EMAIL_IS_REQUIRED)
   @Email(message = Constants.VALIDATION_ORGANIZATION_OWNER_CONTACT_EMAIL_IS_INVALID_FORMAT)

--- a/services/beeja-accounts/src/main/java/com/beeja/api/accounts/repository/OrganizationRepository.java
+++ b/services/beeja-accounts/src/main/java/com/beeja/api/accounts/repository/OrganizationRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface OrganizationRepository extends MongoRepository<Organization, String> {
 
@@ -14,4 +16,5 @@ public interface OrganizationRepository extends MongoRepository<Organization, St
   @Query(value = "{ 'id' : ?0 }")
   OrganizationResponse findByOrganizationId(String id);
 
+  List<Organization> findByIsBirthDayNotificationEnabled(boolean enabled);
 }

--- a/services/beeja-accounts/src/main/java/com/beeja/api/accounts/service/OrganizationService.java
+++ b/services/beeja-accounts/src/main/java/com/beeja/api/accounts/service/OrganizationService.java
@@ -26,4 +26,10 @@ public interface OrganizationService {
   List<OrgDefaults> getOrganizationValues(List<String> keys) throws Exception;
 
   void generateOrganizationDefaults() throws Exception;
+
+  List<String> getOrganizationsWithBirthdayNotificationsEnabled() throws Exception;
+
+  String getBirthdayWebhookUrl(String orgId) throws Exception;
+
+  void updateBirthdayPreference(String orgId, boolean enabled, String webhookUrl) throws Exception;
 }

--- a/services/beeja-accounts/src/main/java/com/beeja/api/accounts/serviceImpl/OrganizationServiceImpl.java
+++ b/services/beeja-accounts/src/main/java/com/beeja/api/accounts/serviceImpl/OrganizationServiceImpl.java
@@ -36,6 +36,7 @@ import com.beeja.api.accounts.utils.Constants;
 import com.beeja.api.accounts.utils.UserContext;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
@@ -59,6 +60,7 @@ import java.util.stream.Collectors;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class OrganizationServiceImpl implements OrganizationService {
 
   @Autowired OrganizationRepository organizationRepository;
@@ -588,4 +590,29 @@ public class OrganizationServiceImpl implements OrganizationService {
     allFutures.join();
     log.info("All defaults generated");
   }
+  @Override
+  public List<String> getOrganizationsWithBirthdayNotificationsEnabled() {
+    return organizationRepository.findByIsBirthDayNotificationEnabled(true)
+            .stream()
+            .map(Organization::getId)
+
+            .collect(Collectors.toList());
+  }
+
+  @Override
+  public String getBirthdayWebhookUrl(String orgId) {
+    return organizationRepository.findById(orgId)
+            .map(Organization::getBirthdayWebhookUrl)
+            .orElse(null);
+  }
+  @Override
+  public void updateBirthdayPreference(String orgId, boolean enabled, String webhookUrl) {
+    Organization org = organizationRepository.findById(orgId)
+            .orElseThrow(() -> new ResourceNotFoundException("Organization not found"));
+
+    org.setBirthDayNotificationEnabled(enabled);
+    org.setBirthdayWebhookUrl(enabled ? webhookUrl : null);
+    organizationRepository.save(org);
+  }
+
 }

--- a/services/beeja-employee-management/src/main/java/com/beeja/api/employeemanagement/controller/EmployeeController.java
+++ b/services/beeja-employee-management/src/main/java/com/beeja/api/employeemanagement/controller/EmployeeController.java
@@ -3,6 +3,7 @@ package com.beeja.api.employeemanagement.controller;
 import com.beeja.api.employeemanagement.annotations.HasPermission;
 import com.beeja.api.employeemanagement.constants.PermissionConstants;
 import com.beeja.api.employeemanagement.model.Employee;
+import com.beeja.api.employeemanagement.model.EmployeeDTO;
 import com.beeja.api.employeemanagement.requests.EmployeeUpdateRequest;
 import com.beeja.api.employeemanagement.requests.UpdateKYCRequest;
 import com.beeja.api.employeemanagement.response.EmployeeResponse;
@@ -92,5 +93,10 @@ public class EmployeeController {
   @GetMapping("/employee-values")
   ResponseEntity<EmployeeValues> getEmployeeValues() throws Exception {
     return ResponseEntity.ok(employeeService.getEmployeeValues());
+  }
+
+  @GetMapping("/all-employees/{orgId}")
+  ResponseEntity<List<EmployeeDTO>> getAll(@PathVariable String orgId)throws Exception{
+    return ResponseEntity.ok(employeeService.getAll(orgId));
   }
 }

--- a/services/beeja-employee-management/src/main/java/com/beeja/api/employeemanagement/model/EmployeeDTO.java
+++ b/services/beeja-employee-management/src/main/java/com/beeja/api/employeemanagement/model/EmployeeDTO.java
@@ -1,0 +1,20 @@
+package com.beeja.api.employeemanagement.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmployeeDTO {
+    @Id
+    private String id;
+    private String beejaAccountId;
+    private String employeeId;
+    private String employmentType;
+    private String organizationId;
+    private Address address;
+    private PersonalInformation personalInformation;
+}

--- a/services/beeja-employee-management/src/main/java/com/beeja/api/employeemanagement/model/clients/accounts/OrganizationDTO.java
+++ b/services/beeja-employee-management/src/main/java/com/beeja/api/employeemanagement/model/clients/accounts/OrganizationDTO.java
@@ -1,5 +1,6 @@
 package com.beeja.api.employeemanagement.model.clients.accounts;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,7 @@ import java.util.HashMap;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OrganizationDTO {
   private String id;
   private String name;

--- a/services/beeja-employee-management/src/main/java/com/beeja/api/employeemanagement/repository/EmployeeRepository.java
+++ b/services/beeja-employee-management/src/main/java/com/beeja/api/employeemanagement/repository/EmployeeRepository.java
@@ -1,6 +1,7 @@
 package com.beeja.api.employeemanagement.repository;
 
 import com.beeja.api.employeemanagement.model.Employee;
+import com.beeja.api.employeemanagement.model.EmployeeDTO;
 import com.beeja.api.employeemanagement.response.EmployeeDefaultValues;
 import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -29,6 +30,6 @@ public interface EmployeeRepository extends MongoRepository<Employee, String> {
   })
   List<EmployeeDefaultValues> findDistinctTypeByOrganizationId(String organizationId);
 
-
+  List<EmployeeDTO> findAllByOrganizationId(String orgId);
 
 }

--- a/services/beeja-employee-management/src/main/java/com/beeja/api/employeemanagement/service/EmployeeService.java
+++ b/services/beeja-employee-management/src/main/java/com/beeja/api/employeemanagement/service/EmployeeService.java
@@ -1,6 +1,7 @@
 package com.beeja.api.employeemanagement.service;
 
 import com.beeja.api.employeemanagement.model.Employee;
+import com.beeja.api.employeemanagement.model.EmployeeDTO;
 import com.beeja.api.employeemanagement.requests.EmployeeUpdateRequest;
 import com.beeja.api.employeemanagement.requests.UpdateKYCRequest;
 import com.beeja.api.employeemanagement.response.EmployeeResponse;
@@ -40,4 +41,7 @@ public interface EmployeeService {
   Employee uploadOrUpdateProfilePic(MultipartFile file, String employeeId) throws Exception;
 
   EmployeeValues getEmployeeValues() throws Exception;
+
+  List<EmployeeDTO> getAll(String orgId) throws Exception;
+
 }

--- a/services/beeja-employee-management/src/main/java/com/beeja/api/employeemanagement/serviceImpl/EmployeeServiceImpl.java
+++ b/services/beeja-employee-management/src/main/java/com/beeja/api/employeemanagement/serviceImpl/EmployeeServiceImpl.java
@@ -1,5 +1,6 @@
 package com.beeja.api.employeemanagement.serviceImpl;
 
+import com.beeja.api.employeemanagement.model.*;
 import com.beeja.api.employeemanagement.response.EmployeeDefaultValues;
 import com.beeja.api.employeemanagement.response.EmployeeValues;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -787,4 +788,9 @@ public class EmployeeServiceImpl implements EmployeeService {
     }
     return "Duplicate entry found.";
   }
+    @Override
+    public List<EmployeeDTO> getAll(String orgId) {
+        return employeeRepository.findAllByOrganizationId(orgId);
+    }
+
 }


### PR DESCRIPTION
This module is designed to send birthday reminders for employees via Microsoft Teams webhooks. It enables each organization to manage its own birthday notification settings and webhook configurations.

Core Purpose

To automate and simplify birthday greetings in organizations by:
- Allowing each organization to enable/disable birthday notifications.
- Saving Microsoft Teams webhook URLs for sending automated messages.
- Efficiently fetching eligible employees using lightweight DTOs.

Key Features:

- Enable/Disable birthday notifications for each organization
- Securely store Microsoft Teams webhook URL in the organization document
- Fetch list of organizations with birthday notifications enabled
- Retrieve webhook URL for specific organization
- Optimized employee data retrieval using lightweight DTO

Microservices Involved:

account-service

- API to update birthday notification preferences.
- Stores webhook URL and notification enabled flag in Organization document.
- Provides internal APIs to fetch enabled orgs and their webhook URLs.

employee-service

- Exposes API to return all employees for a given organization.
- Optimized using EmployeeDTO for lightweight data transfer.