### PR TITLE
Bugfix: fixed auto redirect to general tab when updating job fields

### DIFF
--- a/web/src/components/reusableComponents/MyProfileTabsContainer.component.tsx
+++ b/web/src/components/reusableComponents/MyProfileTabsContainer.component.tsx
@@ -41,7 +41,6 @@ const MyProfileTabsContainerComponent = ({
   const [isActiveTab, setIsActiveTab] = useState('general');
   useEffect(() => {
     setSelectedTab('general');
-    setIsActiveTab('general');
   }, [employee]);
 
   useEffect(() => {


### PR DESCRIPTION
User can stay in the same screen after updating the job details. it will not redirect to general Tab.