### PR TITLE
fix:fixed action button highlight state across all modules

### DIFF
--- a/web/src/components/reusableComponents/DocumentAction.tsx
+++ b/web/src/components/reusableComponents/DocumentAction.tsx
@@ -98,6 +98,7 @@ export const DocumentAction: React.FC<ActionProps> = ({
       documentPreview(fileName, fileId);
     }
     setIsOpen(false);
+    setSelectedOption(null);
     // onOptionSelect(option);
   };
 

--- a/web/src/components/reusableComponents/ExpenseListAction.tsx
+++ b/web/src/components/reusableComponents/ExpenseListAction.tsx
@@ -84,6 +84,7 @@ export const ExpenseAction: React.FC<ActionProps> = ({
       handleIsEditModalOpen();
     }
     setIsOpen(false);
+    setSelectedOption(null);
     // onOptionSelect(option);
   };
 

--- a/web/src/components/reusableComponents/ExpenseTyeAction.tsx
+++ b/web/src/components/reusableComponents/ExpenseTyeAction.tsx
@@ -32,6 +32,7 @@ export const ExpenseTypeAction: React.FC<ExpenseActionProps> = ({
   const handleActionClick = (action: string) => {
     setSelectedOption(action);
     onActionClick(action, currentExpense);
+    setSelectedOption(null);
     setIsOpen(false);
   };
   const [isOpen, setIsOpen] = useState(false);

--- a/web/src/components/reusableComponents/InventoryListAction.component.tsx
+++ b/web/src/components/reusableComponents/InventoryListAction.component.tsx
@@ -71,6 +71,7 @@ export const InventoryListAction: React.FC<ActionProps> = ({
       setConfirmDeleteModal(true);
     }
     setIsOpen(false);
+    setSelectedOption(null);
   };
   const deleteSelectedDevice = async () => {
     try {


### PR DESCRIPTION
This PR Introduces:

- Fixed false active state for action buttons – ensured only the currently active action button is highlighted (greyed out), and others are reset.

- Improved UI feedback consistency – updated button states to reflect the latest user action, preventing misleading visual states.