### PR TITLE
fix:Hide Pagination Controls When Referral List is Empty

### DIFF
--- a/web/src/screens/LoanManagementScreen.screen.tsx
+++ b/web/src/screens/LoanManagementScreen.screen.tsx
@@ -29,10 +29,9 @@ const LoanManagementScreen = () => {
   const [loading, setLoading] = useState(false);
 
   const goToPreviousPage = () => {
-    if(isApplyLoanScreen){
+    if (isApplyLoanScreen) {
       setIsApplyLoanScreen(false);
-    }
-    else{
+    } else {
       navigate(-1);
     }
   };

--- a/web/src/screens/RecruitmentManagementScreen.screen.tsx
+++ b/web/src/screens/RecruitmentManagementScreen.screen.tsx
@@ -112,14 +112,16 @@ const RecruitmentManagementScreen = (
           currentPage={currentPage}
           setCurrentPage={setCurrentPage}
         />
-        <Pagination
-          currentPage={currentPage}
-          totalPages={Math.max(1, Math.ceil(totalItems / itemsPerPage))}
-          handlePageChange={handlePageChange}
-          itemsPerPage={itemsPerPage}
-          handleItemsPerPage={handlePageSizeChange}
-          totalItems={totalItems}
-        />
+        {allApplicants.length > 0 && (
+          <Pagination
+            currentPage={currentPage}
+            totalPages={Math.max(1, Math.ceil(totalItems / itemsPerPage))}
+            handlePageChange={handlePageChange}
+            itemsPerPage={itemsPerPage}
+            handleItemsPerPage={handlePageSizeChange}
+            totalItems={totalItems}
+          />
+        )}
       </ExpenseManagementMainContainer>
     </>
   );


### PR DESCRIPTION
fixed: when the referral data list is empty pagination controls are not displayed.