### PR TITLE
Fix Newly added mode of payment with Expense module filters and forms

### DIFF
--- a/web/src/screens/LoanManagementScreen.screen.tsx
+++ b/web/src/screens/LoanManagementScreen.screen.tsx
@@ -29,10 +29,9 @@ const LoanManagementScreen = () => {
   const [loading, setLoading] = useState(false);
 
   const goToPreviousPage = () => {
-    if(isApplyLoanScreen){
+    if (isApplyLoanScreen) {
       setIsApplyLoanScreen(false);
-    }
-    else{
+    } else {
       navigate(-1);
     }
   };

--- a/web/src/screens/OrganizationSettings.screen.tsx
+++ b/web/src/screens/OrganizationSettings.screen.tsx
@@ -485,10 +485,7 @@ const OrganizationSettings = () => {
               <SettingsTypes keyvalue="expenseTypes" type="Expense Type" />
             )}
             {activeTab === 'ModeOfPayments' && (
-              <SettingsTypes
-                keyvalue="expensePaymentTypes"
-                type="Mode Of Payment"
-              />
+              <SettingsTypes keyvalue="paymentModes" type="Mode Of Payment" />
             )}
             {activeTab === 'ExpenseCategories' && (
               <SettingsTypes


### PR DESCRIPTION
This PR introduces: 

1. Fixes the issue where newly added modes of payment under Settings > Expense > Mode of Payments were not reflected in the Expense module. 
2. The update ensures that these entries now appear in both the filter dropdown and the Add Expense form, maintaining consistency and allowing users to select the newly created modes.