### PR TITLE
Fix: Conditionally enable OS and RAM fields based on selected device type

### DIFF
--- a/web/src/components/directComponents/AddInventoryForm.component.tsx
+++ b/web/src/components/directComponents/AddInventoryForm.component.tsx
@@ -1,4 +1,11 @@
+import axios from 'axios';
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { DeviceDetails } from '../../entities/InventoryEntity';
+import { OrganizationValues } from '../../entities/OrgValueEntity';
+import { postInventory } from '../../service/axiosInstance';
+import useKeyPress from '../../service/keyboardShortcuts/onKeyPress';
+import useKeyCtrl from '../../service/keyboardShortcuts/onKeySave';
 import { Button } from '../../styles/CommonStyles.style';
 import {
   InputLabelContainer,
@@ -7,17 +14,10 @@ import {
 } from '../../styles/DocumentTabStyles.style';
 import { ExpenseAddFormMainContainer } from '../../styles/ExpenseManagementStyles.style';
 import { CalenderIconDark } from '../../svgs/ExpenseListSvgs.svg';
-import Calendar from '../reusableComponents/Calendar.component';
-import { postInventory } from '../../service/axiosInstance';
-import ToastMessage from '../reusableComponents/ToastMessage.component';
-import { DeviceDetails } from '../../entities/InventoryEntity';
 import SpinAnimation from '../loaders/SprinAnimation.loader';
-import axios from 'axios';
-import useKeyCtrl from '../../service/keyboardShortcuts/onKeySave';
-import useKeyPress from '../../service/keyboardShortcuts/onKeyPress';
+import Calendar from '../reusableComponents/Calendar.component';
 import { Availability } from '../reusableComponents/InventoryEnums.component';
-import { OrganizationValues } from '../../entities/OrgValueEntity';
-import { useTranslation } from 'react-i18next';
+import ToastMessage from '../reusableComponents/ToastMessage.component';
 
 type AddInventoryFormProps = {
   handleClose: () => void;
@@ -329,9 +329,16 @@ const AddInventoryForm = (props: AddInventoryFormProps) => {
             <InputLabelContainer>
               <label>
                 OS
-                {['Desktop', 'MUSIC_SYSTEM', 'Printer', 'Accessories'].includes(
-                  formData.device
-                ) ? null : (
+                {[
+                  'Desktop',
+                  'Laptop',
+                  'Mobile',
+                  'Tablet',
+                  'Desktops',
+                  'Laptops',
+                  'Mobiles',
+                  'Tablets',
+                ].includes(formData.device) && (
                   <ValidationText className="star">*</ValidationText>
                 )}
               </label>
@@ -339,37 +346,48 @@ const AddInventoryForm = (props: AddInventoryFormProps) => {
                 type="text"
                 name="os"
                 placeholder={t('EXAMPLE_MAC_OS')}
-                value={formData.os ? formData.os : ''}
-                className="largeInput"
+                value={formData.os || ''}
                 onChange={handleChange}
-                disabled={
-                  !(
-                    formData.device === 'Desktops' ||
-                    formData.device === 'Laptops' ||
-                    formData.device === 'Mobiles' ||
-                    formData.device === 'Tablets' ||
-                    formData.device === 'Desktop' ||
-                    formData.device === 'Laptop' ||
-                    formData.device === 'Mobile' ||
-                    formData.device === 'Tablet'
-                  )
-                }
-                required={
-                  ![
-                    'Printer',
-                    'MUSIC_SYSTEM',
-                    'Desktop',
-                    'Accessories',
-                  ].includes(formData.device)
-                }
+                disabled={Boolean(
+                  formData.device &&
+                    formData.device !== 'Select Device' &&
+                    ![
+                      'Desktop',
+                      'Laptop',
+                      'Mobile',
+                      'Tablet',
+                      'Desktops',
+                      'Laptops',
+                      'Mobiles',
+                      'Tablets',
+                    ].includes(formData.device)
+                )}
+                required={[
+                  'Desktop',
+                  'Laptop',
+                  'Mobile',
+                  'Tablet',
+                  'Desktops',
+                  'Laptops',
+                  'Mobiles',
+                  'Tablets',
+                ].includes(formData.device)}
+                className="largeInput"
               />
             </InputLabelContainer>
             <InputLabelContainer>
               <label>
                 {t('RAM')}
-                {['Desktop', 'MUSIC_SYSTEM', 'Printer', 'Accessories'].includes(
-                  formData.device
-                ) ? null : (
+                {[
+                  'Desktop',
+                  'Laptop',
+                  'Mobile',
+                  'Tablet',
+                  'Desktops',
+                  'Laptops',
+                  'Mobiles',
+                  'Tablets',
+                ].includes(formData.device) && (
                   <ValidationText className="star">*</ValidationText>
                 )}
               </label>
@@ -377,19 +395,34 @@ const AddInventoryForm = (props: AddInventoryFormProps) => {
                 type="text"
                 placeholder={t('ENTER_IN_GB')}
                 name="ram"
-                value={formData.ram ? formData.ram : ''}
+                value={formData.ram || ''}
                 className="largeInput"
                 onChange={handleChange}
-                disabled={formData.device === 'Accessories'}
                 autoComplete="off"
-                required={
-                  ![
-                    'Printer',
-                    'Desktop',
-                    'MUSIC_SYSTEM',
-                    'Accessories',
-                  ].includes(formData.device)
-                }
+                disabled={Boolean(
+                  formData.device &&
+                    formData.device !== 'Select Device' &&
+                    ![
+                      'Desktop',
+                      'Laptop',
+                      'Mobile',
+                      'Tablet',
+                      'Desktops',
+                      'Laptops',
+                      'Mobiles',
+                      'Tablets',
+                    ].includes(formData.device)
+                )}
+                required={[
+                  'Desktop',
+                  'Laptop',
+                  'Mobile',
+                  'Tablet',
+                  'Desktops',
+                  'Laptops',
+                  'Mobiles',
+                  'Tablets',
+                ].includes(formData.device)}
                 onKeyDown={(event) => {
                   const allowedCharacters = /^[0-9.-]+$/;
                   if (
@@ -404,6 +437,7 @@ const AddInventoryForm = (props: AddInventoryFormProps) => {
                 }}
               />
             </InputLabelContainer>
+
             <InputLabelContainer>
               <label>
                 {t('PRODUCT_ID_SERIAL_NUMBER')}

--- a/web/src/styles/ExpenseManagementStyles.style.tsx
+++ b/web/src/styles/ExpenseManagementStyles.style.tsx
@@ -66,6 +66,12 @@ export const ExpenseAddFormMainContainer = styled.form`
     outline: none;
     cursor: pointer;
   }
+
+  input:disabled {
+    color: #a0a0a0;
+    background-color: #f5f5f5;
+    cursor: not-allowed;
+  }
 `;
 
 export const FileUploadField = styled.div`


### PR DESCRIPTION
This PR Introduced:-

1. Implemented conditional logic to enable and validate OS and RAM fields only for devices that support them (e.g.,  Laptop, Desktop, Mobile, Tablet,).

2. Disabled fields now display in light grey to indicate non-applicability, improving user experience and form accuracy.