### PR TITLE
Fix: Correct employee count mismatch in pagination for status filter

### DIFF
--- a/services/beeja-employee-management/src/main/java/com/beeja/api/employeemanagement/controller/EmployeeController.java
+++ b/services/beeja-employee-management/src/main/java/com/beeja/api/employeemanagement/controller/EmployeeController.java
@@ -39,7 +39,7 @@ public class EmployeeController {
       @RequestParam(name = "department", required = false) String department,
       @RequestParam(name = "designation", required = false) String designation,
       @RequestParam(name = "employmentType", required = false) String employmentType,
-      @RequestParam(name = "status", defaultValue = "active") String status,
+      @RequestParam(name = "status", required = false) String status,
       @RequestParam(name = "pageNumber", defaultValue = "1") int pageNumber,
       @RequestParam(name = "pageSize", defaultValue = "10") int pageSize)
       throws Exception {


### PR DESCRIPTION
This PR Introduces: 

1. Implemented default behavior to fetch both active and inactive employees when no status is selected (By Default).

2. Returns both active and inactive employees by default when no status is selected.

3. Corrects total count logic to reflect actual employee-account mappings.

4. Optimized account data mapping using a Map for faster lookups.

