### PR TITLE
Fixed displaying the Referral Employee name in recruitment List

### DIFF
--- a/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/response/ApplicantDTO.java
+++ b/services/beeja-recruitment/src/main/java/tac/beeja/recruitmentapi/response/ApplicantDTO.java
@@ -19,6 +19,6 @@ public class ApplicantDTO {
   private String positionAppliedFor;
   private ApplicantStatus status;
   private String experience;
-  private String referredBy;
+  private String referredByEmployeeName;
   private Date createdAt;
 }


### PR DESCRIPTION
This PR updates the Applicant DTO by renaming a field to referredByEmployeeName to display the referral employee's name in the 'List of Hiring' section