### PR TITLE
fix:Reset profile tab to 'general' on employee change

### DIFF
--- a/web/src/components/reusableComponents/MyProfileTabsContainer.component.tsx
+++ b/web/src/components/reusableComponents/MyProfileTabsContainer.component.tsx
@@ -41,21 +41,6 @@ const MyProfileTabsContainerComponent = ({
   const [selectedTab, setSelectedTab] = useState('general');
   const [isActiveTab, setIsActiveTab] = useState('general');
   useEffect(() => {
-    const savedTab = localStorage.getItem('selectedTab');
-    if (savedTab) {
-      setSelectedTab(savedTab);
-      setIsActiveTab(savedTab);
-    } else {
-      setSelectedTab('general');
-      setIsActiveTab('general');
-    }
-  }, []);
-
-  useEffect(() => {
-    localStorage.setItem('selectedTab', selectedTab);
-  }, [selectedTab]);
-
-  useEffect(() => {
     setSelectedTab(isActiveTab);
   }, [isActiveTab]);
 


### PR DESCRIPTION
This PR Introduces:

- Removed localStorage/sessionStorage logic used for persisting the selected tab in the profile component.

- Ensured the tab resets to "general" when switching between employee profiles by relying on default component state.