### PR TITLE
fix:fixed blank screen issue in expence while editing

### DIFF
--- a/web/src/components/directComponents/AddExpenseForm.component.tsx
+++ b/web/src/components/directComponents/AddExpenseForm.component.tsx
@@ -91,8 +91,8 @@ const AddExpenseForm = (props: AddExpenseFormProps) => {
   };
 
   const fileId: string =
-    props.expense?.fileId && props.expense?.files && props.expense?.files[0].id
-      ? props.expense?.fileId && props.expense?.files[0].id
+    props.expense?.fileId && props.expense?.files && props.expense?.files[0]?.id
+      ? props.expense?.fileId && props.expense?.files[0]?.id
       : '';
   const [images, setImages] = useState(null);
   const [fileExtension, setFileExtension] = useState<string>();


### PR DESCRIPTION
This PR Introduces:

- Fixed blank screen issue in expence management while editing.
- Now user can manage expense records smoothly without the system entering into a blank state.