### PR TITLE
bugfix: fixed Font Size for Employee List Page Title

### DIFF
--- a/web/src/styles/EmployeeListStyles.style.tsx
+++ b/web/src/styles/EmployeeListStyles.style.tsx
@@ -25,6 +25,12 @@ export const EmployeeListHeadSection = styled.div`
   align-items: center;
   flex-wrap: wrap;
 
+  h3 {
+    font-size: 24px;
+    font-style: normal;
+    font-weight: 550;
+  }
+
   div {
     display: flex;
 


### PR DESCRIPTION
This PR introduces:
The Employee List page title is now in the standard font size which is applied to all other module headers.
