### PR TITLE
Fix/Remove-Nav-Links for (documents and payslip) 

### DIFF
--- a/web/src/components/reusableComponents/TopNavBar.component.tsx
+++ b/web/src/components/reusableComponents/TopNavBar.component.tsx
@@ -99,16 +99,16 @@ const TopNavBarComponent = ({ employee }: topNavBarProps) => {
         {isMenuExpanded && <MobileNavbar handleIsOpen={handleIsMenuExpanded} />}
       </span>
       <span className="mainTopNav">
-        {/*} <SearchBox className="search">
+        {/* <SearchBox className="search">
           <span className="span">
             <SearchSVG />
             <SearchInput placeholder={t('Search anything...')} />
           </span>
-        </SearchBox>*/}
+        </SearchBox>
         <span className="topNavLinks">
           <span>{t('DOCUMENTS')}</span>
           <span>{t('PAYSLIPS')}</span>
-        </span>
+        </span> */}
       </span>
       <TopNavRightIcons>
         <span className="language">


### PR DESCRIPTION
Fix: Removed Navigation Links (documents and payslip) from top-NavBar

Structural Integrity is maintained for the remaining top-NavBar.
Comments have also been added in the files for easier fixing later.