### PR TITLE
Fix: Device Type Display while editing form in Inventory

### DIFF
--- a/web/src/components/directComponents/EditInventory.component.tsx
+++ b/web/src/components/directComponents/EditInventory.component.tsx
@@ -162,7 +162,6 @@ const EditInventoryForm: React.FC<EditInventoryFormProps> = ({
         : null
     );
   }, [initialFormData]);
-
   return (
     <>
       <ExpenseAddFormMainContainer onSubmit={handleSubmitData}>
@@ -182,7 +181,7 @@ const EditInventoryForm: React.FC<EditInventoryFormProps> = ({
               >
                 <option value="">{t('SELECT_DEVICE')}</option>
                 {deviceTypes?.values?.map((device) => (
-                  <option key={device.value} value={device.value}>
+                  <option key={device.value} value={device.value.toUpperCase()}>
                     {device.description || device.value}
                   </option>
                 ))}


### PR DESCRIPTION
Fix: Device-Type is displayed when the edit form is opened in Inventory.