### PR TITLE
Generated the Default Document types

### DIFF
--- a/services/beeja-accounts/src/main/java/com/beeja/api/accounts/serviceImpl/OrganizationServiceImpl.java
+++ b/services/beeja-accounts/src/main/java/com/beeja/api/accounts/serviceImpl/OrganizationServiceImpl.java
@@ -691,6 +691,19 @@ public class OrganizationServiceImpl implements OrganizationService {
                   }
                   return result;
                 });
+    CompletableFuture<Void> documentTypesFuture =
+            CompletableFuture.runAsync(() -> {
+              orgDefaultsGenerationImpl.generateDocumentTypes();
+            }).handle((result, ex) -> {
+              if (ex != null) {
+                log.error(Constants.ERROR_GENERATING_DEFAULT_VALUES,
+                        "documentTypes",
+                        UserContext.getLoggedInUserOrganization().getId(),
+                        ex);
+              }
+              return result;
+            });
+
     CompletableFuture<Void> allFutures =
         CompletableFuture.allOf(
             jobTitlesFuture,
@@ -699,6 +712,7 @@ public class OrganizationServiceImpl implements OrganizationService {
             expenseCategoriesFuture,
             expenseTypesFuture,
             paymentModesFuture,
+            documentTypesFuture,
             generateExistingValuesOfExpenseType,
             generateExistingValuesOfExpenseCategories,
             generateExistingPaymentModes,


### PR DESCRIPTION
This PR Introduced:

- Implemented logic to auto-generate default document types (Identity, PaySlip, NDA, Appraisal Letter, Equipment Policy, Address Proof, Tax Exit Doc. 