### PR TITLE
bugfix: handle edit when requestedDate is empty to prevent white screen in Expense Management

### DIFF
--- a/web/src/components/directComponents/AddExpenseForm.component.tsx
+++ b/web/src/components/directComponents/AddExpenseForm.component.tsx
@@ -834,18 +834,24 @@ const AddExpenseForm = (props: AddExpenseFormProps) => {
   const [requestedDate, setRequestedDate] = useState<Date | null>();
   const [paymentDate, setPaymentDate] = useState<Date | null>();
   useEffect(() => {
-    if (modeOfModal == 'edit' && props.expense) {
-      setExpenseDate(
-        new Date(formatDateYYYYMMDD(props.expense?.expenseDate.toString()))
-      );
-      if (props.expense && props.expense.paymentDate) {
-        setPaymentDate(
-          new Date(formatDateYYYYMMDD(props.expense?.paymentDate.toString()))
+    if (modeOfModal === 'edit' && props.expense) {
+      if (props.expense.expenseDate) {
+        setExpenseDate(
+          new Date(formatDateYYYYMMDD(String(props.expense.expenseDate)))
         );
       }
-      setRequestedDate(
-        new Date(formatDateYYYYMMDD(props.expense?.requestedDate.toString()))
-      );
+
+      if (props.expense.paymentDate) {
+        setPaymentDate(
+          new Date(formatDateYYYYMMDD(String(props.expense.paymentDate)))
+        );
+      }
+
+      if (props.expense.requestedDate) {
+        setRequestedDate(
+          new Date(formatDateYYYYMMDD(String(props.expense.requestedDate)))
+        );
+      }
     }
   }, [modeOfModal, props.expense, props.expense?.expenseDate]);
 


### PR DESCRIPTION
This PR introduces:
When a user adds an expense in the Expense Management module without providing a value in the Request Date field, the record is successfully created. However, when attempting to edit the same expense record (with no request date), the system is now preventing a white screen and opening the edit form.