### PR TITLE
fix: preserve selected value in dropdown during edit mode

### DIFF
--- a/web/src/components/reusableComponents/DropDownMenu.component.tsx
+++ b/web/src/components/reusableComponents/DropDownMenu.component.tsx
@@ -169,6 +169,7 @@ export const DropdownOrg: React.FC<DropdownMenuProps> = ({
   className = '',
   options,
   value = null,
+  selected: selectedProp,
   style,
   onKeyDown,
   onChange,
@@ -176,6 +177,7 @@ export const DropdownOrg: React.FC<DropdownMenuProps> = ({
   required,
   listClassName = '',
 }) => {
+  const initialValue = selectedProp ?? value ?? null;
   const [isOpen, setIsOpen] = useState(false);
   const [selected, setSelected] = useState<string | null>(value ?? null);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -194,8 +196,8 @@ export const DropdownOrg: React.FC<DropdownMenuProps> = ({
   }, []);
 
   useEffect(() => {
-    setSelected(value ?? null);
-  }, [value]);
+    setSelected(initialValue);
+  }, [initialValue]);
 
   const handleSelect = (item: { label: string; value: string | null }) => {
     setSelected(item.value);

--- a/web/src/styles/MyProfile.style.tsx
+++ b/web/src/styles/MyProfile.style.tsx
@@ -586,7 +586,7 @@ export const StyledCalendarIconDark = styled.div`
   align-items: center;
   width: 30px;
   height: 30px;
-  right: 50px;
+  right: 10px;
 `;
 
 export const CalendarContainer = styled.div`


### PR DESCRIPTION
- Fixed an issue where the dropdown did not display the previously selected value in edit mode.

- Adjusted the alignment of the calendar icon in the Joining Date field of the job section to ensure proper spacing and consistent layout with the input field.